### PR TITLE
🐛 Fix: Duplicate /api prefix causing 404 on menu-packages endpoint

### DIFF
--- a/apps/frontend/lib/api/menu-packages.ts
+++ b/apps/frontend/lib/api/menu-packages.ts
@@ -17,7 +17,7 @@ import type {
  * and their category settings
  */
 
-const BASE_URL = '/api/menu-packages';
+const BASE_URL = '/menu-packages';
 
 /**
  * Get all packages
@@ -183,7 +183,7 @@ export async function updatePackageCategories(
 export async function getDishCategories(): Promise<DishCategory[]> {
   try {
     const response = await apiClient.get<PaginatedResponse<DishCategory>>(
-      '/api/dish-categories'
+      '/dish-categories'
     );
 
     if (response.success && response.data) {


### PR DESCRIPTION
## Problem
❌ Menu packages endpoint zwracał 404 - frontend próbował się połączyć z `/api/api/menu-packages`

## Root Cause
`apiClient` w `lib/api-client.ts` ma już ustawiony `baseURL: 'http://localhost:3001/api'`

Ale `menu-packages.ts` używał:
```typescript
const BASE_URL = '/api/menu-packages';  // ❌
```

To powodowało podwójne `/api`:
```
http://localhost:3001/api + /api/menu-packages = 
http://localhost:3001/api/api/menu-packages  ❌❌❌
```

## Rozwiązanie
✅ Usunięto duplikujący się `/api` prefix:

**Przed:**
```typescript
const BASE_URL = '/api/menu-packages';  // ❌ 404
```

**Po:**
```typescript
const BASE_URL = '/menu-packages';      // ✅ 200
```

## Zmiany
- ✅ Poprawiono `BASE_URL` w `menu-packages.ts`
- ✅ Dodatkowo poprawiono endpoint `getDishCategories()` (miał ten sam problem)

## Testing
```bash
# Backend działa poprawnie:
curl http://localhost:3001/api/menu-packages
✅ {"success":true,"data":[...]}

# Po tej poprawce frontend też będzie działał!
```

## Logs Before Fix
```
2026-02-11T185605.000Z INFO - GET apiapimenu-packages  ❌
                                    ^^^^^^^ podwójne api!
```

## Impact
🎯 Naprawia błąd ładowania pakietów menu w dashboardzie