### PR TITLE
🐛 Fix: Backend Validation - Numbers + Hash + Separate CategorySettings

### DIFF
--- a/apps/frontend/components/menu/PackageForm.tsx
+++ b/apps/frontend/components/menu/PackageForm.tsx
@@ -49,7 +49,7 @@ export default function PackageForm({
     displayOrder: initialData?.displayOrder || 0,
     isPopular: initialData?.isPopular || false,
     isRecommended: initialData?.isRecommended || false,
-    color: initialData?.color || '3b82f6',
+    color: initialData?.color?.replace('#', '') || '3b82f6',
     icon: initialData?.icon || '🎂',
     badgeText: initialData?.badgeText || '',
   });
@@ -155,6 +155,35 @@ export default function PackageForm({
     return true;
   }
 
+  async function saveCategorySettings(packageId: string) {
+    const enabledSettings = categorySettings.filter((cs) => cs.isEnabled);
+    
+    if (enabledSettings.length === 0) return;
+
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/api/menu-packages/${packageId}/categories`,
+        {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+          body: JSON.stringify({ settings: enabledSettings }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to save category settings');
+      }
+
+      console.log('Category settings saved successfully');
+    } catch (error) {
+      console.error('Error saving category settings:', error);
+      throw error;
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
 
@@ -169,39 +198,58 @@ export default function PackageForm({
     );
 
     try {
-      // Clean color (remove # if present)
+      // Clean color (remove # if present) and add it back
       const cleanColor = formData.color.replace('#', '');
+      const colorWithHash = `#${cleanColor}`;
 
-      const packageData: CreatePackageInput | UpdatePackageInput = {
+      // Parse prices to numbers
+      const pricePerAdult = parseFloat(formData.pricePerAdult);
+      const pricePerChild = parseFloat(formData.pricePerChild);
+      const pricePerToddler = parseFloat(formData.pricePerToddler) || 0;
+
+      const packageData: any = {
         name: formData.name.trim(),
         description: formData.description.trim() || null,
         shortDescription: formData.shortDescription.trim() || null,
-        pricePerAdult: formData.pricePerAdult,
-        pricePerChild: formData.pricePerChild,
-        pricePerToddler: formData.pricePerToddler || '0',
+        pricePerAdult,
+        pricePerChild,
+        pricePerToddler,
         displayOrder: formData.displayOrder,
         isPopular: formData.isPopular,
         isRecommended: formData.isRecommended,
-        color: cleanColor,
+        color: colorWithHash,
         icon: formData.icon || null,
         badgeText: formData.badgeText.trim() || null,
-        menuTemplateId,
-        categorySettings: categorySettings.filter((cs) => cs.isEnabled),
       };
+
+      // Add menuTemplateId only for create
+      if (!initialData) {
+        packageData.menuTemplateId = menuTemplateId;
+      }
 
       console.log('Sending package data:', packageData);
 
+      let createdOrUpdatedPackage;
+
       if (initialData) {
-        // Update
-        await updatePackage(initialData.id, packageData);
+        // Update package
+        createdOrUpdatedPackage = await updatePackage(initialData.id, packageData);
+        
+        // Update category settings
+        await saveCategorySettings(initialData.id);
+        
         toast.success('🎉 Pakiet zaktualizowany!', {
           id: savingToast,
           description: `Pakiet "${formData.name}" został pomyślnie zaktualizowany`,
           duration: 5000,
         });
       } else {
-        // Create
-        await createPackage(packageData as CreatePackageInput);
+        // Create package
+        createdOrUpdatedPackage = await createPackage(packageData as CreatePackageInput);
+        
+        // Save category settings for newly created package
+        await saveCategorySettings(createdOrUpdatedPackage.id);
+        
         toast.success('✨ Pakiet utworzony!', {
           id: savingToast,
           description: `Nowy pakiet "${formData.name}" został dodany do menu`,
@@ -453,13 +501,12 @@ export default function PackageForm({
                 value={formData.color}
                 onChange={handleChange}
                 placeholder="3b82f6"
-                maxLength={6}
-                pattern="[0-9A-Fa-f]{6}"
+                maxLength={7}
                 className="flex-1 px-4 py-2.5 border border-slate-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all font-mono text-sm"
               />
               <div 
                 className="w-12 h-12 rounded-xl border-2 border-slate-300 shadow-sm"
-                style={{ backgroundColor: `#${formData.color}` }}
+                style={{ backgroundColor: `#${formData.color.replace('#', '')}` }}
               ></div>
             </div>
           </div>


### PR DESCRIPTION
## 🐛 Naprawiono Błąd Walidacji

### Problem: 400 Bad Request "Validation error"

Backend wymaga:
1. ❌ Ceny jako **NUMBER** (nie string)
2. ❌ Kolor z **#** na początku (`#3b82f6`)
3. ❌ **categorySettings** osobnym endpointem

### Root Cause Analysis

Sprawdziłem `apps/backend/src/validation/menu.validation.ts`:

```typescript
const createMenuPackageSchema = z.object({
  pricePerAdult: z.number().min(0),      // NUMBER!
  pricePerChild: z.number().min(0),      // NUMBER!
  pricePerToddler: z.number().min(0),    // NUMBER!
  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),  // # required!
  // ... NO categorySettings field!
});
```

I sprawdziłem `apps/backend/src/controllers/packageCategory.controller.ts`:
```typescript
// Osobny endpoint:
PUT /api/menu-packages/:packageId/categories
Body: { settings: CategorySettingInput[] }
```

---

## ✅ Rozwiązanie

### 1. Ceny jako Number
```typescript
// Przed
pricePerAdult: formData.pricePerAdult,  // "180.00"

// Po
pricePerAdult: parseFloat(formData.pricePerAdult),  // 180.00
```

### 2. Kolor z Hash
```typescript
// Przed
color: formData.color,  // "3b82f6"

// Po
const cleanColor = formData.color.replace('#', '');
const colorWithHash = `#${cleanColor}`;  // "#3b82f6"
```

### 3. Osobny Endpoint dla CategorySettings
```typescript
async function saveCategorySettings(packageId: string) {
  const enabledSettings = categorySettings.filter(cs => cs.isEnabled);
  
  const response = await fetch(
    `${process.env.NEXT_PUBLIC_API_URL}/api/menu-packages/${packageId}/categories`,
    {
      method: 'PUT',
      headers: { 'Content-Type': 'application/json' },
      credentials: 'include',
      body: JSON.stringify({ settings: enabledSettings }),
    }
  );
}

// Workflow:
// 1. Utwórz pakiet (bez categorySettings)
// 2. Zapisz categorySettings osobno
const createdPackage = await createPackage(packageData);
await saveCategorySettings(createdPackage.id);
```

---

## 🔧 Technical Changes

### Package Data Structure
```typescript
const packageData = {
  name: formData.name.trim(),
  description: formData.description.trim() || null,
  shortDescription: formData.shortDescription.trim() || null,
  
  // Parse to numbers
  pricePerAdult: parseFloat(formData.pricePerAdult),
  pricePerChild: parseFloat(formData.pricePerChild),
  pricePerToddler: parseFloat(formData.pricePerToddler) || 0,
  
  displayOrder: formData.displayOrder,
  isPopular: formData.isPopular,
  isRecommended: formData.isRecommended,
  
  // Add hash
  color: `#${formData.color.replace('#', '')}`,
  
  icon: formData.icon || null,
  badgeText: formData.badgeText.trim() || null,
  
  // Only for create
  menuTemplateId: !initialData ? menuTemplateId : undefined,
};

// NO categorySettings in main payload!
```

### Category Settings Endpoint
```typescript
PUT /api/menu-packages/${packageId}/categories

Payload:
{
  "settings": [
    {
      "categoryId": "uuid",
      "minSelect": 1,
      "maxSelect": 3,
      "isRequired": true,
      "isEnabled": true,
      "displayOrder": 0,
      "customLabel": "Zupy" | null
    }
  ]
}
```

---

## 🧪 Testing Checklist

### Create Package
- [ ] Wprowadź dane pakietu
- [ ] Wybierz kolor z palety
- [ ] Dodaj kategorie
- [ ] Kliknij "Utwórz pakiet"
- [ ] **Powinno działać bez błędów!**

### Update Package
- [ ] Edytuj istniejący pakiet
- [ ] Zmień ceny
- [ ] Zmień kolor
- [ ] Zmień kategorie
- [ ] Zapisz
- [ ] **Powinno działać bez błędów!**

---

## 📊 Validation Flow

```
1. Frontend Validation
   ✓ Name min 3 chars
   ✓ Adult price > 0
   ✓ Child price >= 0
   ✓ Color HEX format
   ✓ Min 1 enabled category

2. Data Transformation
   ✓ Parse prices to numbers
   ✓ Add # to color
   ✓ Trim strings
   ✓ null for empty optionals

3. API Call #1: Create/Update Package
   → POST/PUT /api/menu-packages
   → Backend validates with Zod
   → Returns package with ID

4. API Call #2: Save Category Settings
   → PUT /api/menu-packages/:id/categories
   → Bulk update settings
   → Transaction: delete old + create new

5. Success!
   ✓ Toast notification
   ✓ Redirect
```

---

## 🚀 Deploy

```bash
cd /home/kamil/rezerwacje
git pull origin fix/backend-validation-fix
docker compose restart frontend
```

**Ctrl+Shift+R** w przeglądarce!

---

## 🎯 Summary

| Issue | Before | After |
|-------|--------|-------|
| **Ceny** | String "180.00" | Number 180.00 |
| **Kolor** | "3b82f6" | "#3b82f6" |
| **CategorySettings** | W głównym payload | Osobny endpoint |
| **Endpoint** | Jeden POST | POST + PUT |
| **Walidacja** | ❌ Failed | ✅ Passes |

### Key Files Changed:
- `apps/frontend/components/menu/PackageForm.tsx`
  - Parse prices to numbers
  - Add # to color
  - Remove categorySettings from main payload
  - Add `saveCategorySettings()` function
  - Call separate endpoint after package creation

### Backend Endpoints Used:
1. `POST /api/menu-packages` - create package
2. `PUT /api/menu-packages/:id` - update package
3. `PUT /api/menu-packages/:id/categories` - bulk update category settings