### PR TITLE
🔥 HOTFIX: Add frontend port 3000 to CORS whitelist

### DIFF
--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -29,7 +29,8 @@ const allowedOrigins = [
   'http://localhost:3001',
   'http://127.0.0.1:3000',
   'http://127.0.0.1:3001',
-  'http://62.171.189.172:3001',
+  'http://62.171.189.172:3000',  // Production frontend
+  'http://62.171.189.172:3001',  // Production backend
   process.env.CORS_ORIGIN,
 ].filter(Boolean); // Remove undefined values
 


### PR DESCRIPTION
## 🐛 CRITICAL: CORS Blocking Frontend

### Problem
```
CORS blocked request from origin: http://62.171.189.172:3000
```

**Frontend działa na porcie 3000**, ale w whitelist był tylko port 3001!

### Root Cause

```typescript
// PRZED - brakowało portu 3000!
const allowedOrigins = [
  'http://localhost:3000',
  'http://localhost:3001',
  'http://127.0.0.1:3000',
  'http://127.0.0.1:3001',
  'http://62.171.189.172:3001',  // ✅ Backend
  // ❌ BRAK: 'http://62.171.189.172:3000' - Frontend!
];
```

### Solution

```typescript
// PO - dodany port 3000!
const allowedOrigins = [
  'http://localhost:3000',
  'http://localhost:3001',
  'http://127.0.0.1:3000',
  'http://127.0.0.1:3001',
  'http://62.171.189.172:3000',  // ✅ Production frontend
  'http://62.171.189.172:3001',  // ✅ Production backend
  process.env.CORS_ORIGIN,
].filter(Boolean);
```

### Deploy

```bash
cd /home/kamil/rezerwacje
git pull origin fix/cors-add-frontend-port
docker compose restart backend
```

### Expected Result
- ✅ Frontend (port 3000) can connect to backend
- ✅ No more CORS errors
- ✅ App works normally