### PR TITLE
🔥 HOTFIX: Allow Float Values in Category Settings (0.5, 1.5, 2.5)

### DIFF
--- a/apps/backend/src/validation/menu.validation.ts
+++ b/apps/backend/src/validation/menu.validation.ts
@@ -140,10 +140,16 @@ export const reorderPackagesSchema = z.object({
 // CATEGORY SETTINGS VALIDATION
 // ════════════════════════════════════════════════════════════════════════════
 
+/**
+ * Category Setting Schema
+ * 
+ * SUPPORTS FLOAT VALUES (0.5, 1.5, 2.5, etc) for partial servings
+ * Example: 1.5 portions of salad
+ */
 export const categorySettingSchema = z.object({
   categoryId: z.string().uuid('Invalid category ID'),
-  minSelect: z.number().int().min(0, 'Min selection cannot be negative'),
-  maxSelect: z.number().int().min(1, 'Max selection must be at least 1'),
+  minSelect: z.number().min(0, 'Min selection cannot be negative'),  // ✅ Float allowed
+  maxSelect: z.number().min(0, 'Max selection must be at least 0'),  // ✅ Float allowed
   isRequired: z.boolean().optional().default(true),
   isEnabled: z.boolean().optional().default(true),
   displayOrder: z.number().int().min(0).optional().default(0),


### PR DESCRIPTION
## 🐛 Critical Bug: Integer Validation Too Strict

### Problem
```
Expected integer, received float
path: ['settings', 0, 'maxSelect']
```

**Root Cause:**
- Frontend allows `step="0.5"` for partial servings (1.5 portions, 2.5 portions)
- Backend validation required `.int()` - only whole numbers
- Users can't save settings with values like 1.5, 2.5

---

## ✅ Fix

### Before:
```typescript
export const categorySettingSchema = z.object({
  minSelect: z.number().int().min(0),  // ❌ Only integers: 0, 1, 2, 3
  maxSelect: z.number().int().min(1),  // ❌ Only integers: 1, 2, 3, 4
  // ...
});
```

### After:
```typescript
export const categorySettingSchema = z.object({
  minSelect: z.number().min(0),  // ✅ Floats allowed: 0, 0.5, 1, 1.5, 2, 2.5
  maxSelect: z.number().min(0),  // ✅ Floats allowed: 0, 0.5, 1, 1.5, 2, 2.5
  // ...
});
```

---

## 🎯 Use Case

**Partial Servings:**
- "1-1.5 wyborów (wymagane)" - Guest must select 1-1.5 portions
- "1-2.5 wyborów (wymagane)" - Guest can select up to 2.5 portions
- Useful for:
  - Half portions
  - Shared dishes
  - Kids portions
  - Flexible serving sizes

---

## 🛠️ Technical Details

### Changed Validation:
```typescript
// BEFORE - Strict integers only
minSelect: z.number().int().min(0, 'Min selection cannot be negative'),
maxSelect: z.number().int().min(1, 'Max selection must be at least 1'),

// AFTER - Floats allowed
minSelect: z.number().min(0, 'Min selection cannot be negative'),
maxSelect: z.number().min(0, 'Max selection must be at least 0'),
```

### Why Remove `.int()`?
- Frontend has `<input type="number" step="0.5">` 
- Users can enter 0.5, 1, 1.5, 2, 2.5, etc
- Validation should match UI capabilities
- Decimal.js in Prisma supports floats

---

## 🧪 Testing

### Valid Values:
- ✅ `minSelect: 0, maxSelect: 1`
- ✅ `minSelect: 1, maxSelect: 1.5`
- ✅ `minSelect: 0.5, maxSelect: 2.5`
- ✅ `minSelect: 1.5, maxSelect: 2.5`

### Invalid Values:
- ❌ `minSelect: -1` (negative)
- ❌ `minSelect: 2, maxSelect: 1` (min > max)
- ❌ `minSelect: "abc"` (not a number)

---

## 🚀 Deploy

```bash
cd /home/kamil/rezerwacje
git pull origin fix/allow-float-selections
docker compose restart backend
```

**Ctrl+Shift+R** w przeglądarce!

---

## 📊 Impact

| Aspect | Before | After |
|--------|--------|-------|
| **Allowed Values** | 0, 1, 2, 3... | 0, 0.5, 1, 1.5, 2, 2.5... |
| **Validation Error** | ❌ "Expected integer" | ✅ Accepts floats |
| **Use Case** | ❌ Limited | ✅ Flexible portions |
| **Save Package** | ❌ Fails | ✅ Works |

### Files Changed:
- `apps/backend/src/validation/menu.validation.ts`
  - Removed `.int()` from `minSelect`
  - Removed `.int()` from `maxSelect`
  - Added comment explaining float support
  - Still validates min ≤ max

### Key Benefits:
- ✅ **Flexibility** - Half portions, shared dishes
- ✅ **User-friendly** - Matches frontend UI
- ✅ **No breaking changes** - Integers still work (1.0 = 1)
- ✅ **Type-safe** - Still validates as number

### Why This Matters:
**Real-world scenario:**
- Restaurant offers "1.5 portions of salad" option
- Guest can select 1 or 1.5 portions
- System should support this flexibility
- Integer-only validation was too restrictive