### PR TITLE
fix: handle null queueDate crash on queue page

### DIFF
--- a/apps/backend/prisma/seeds/e2e-test-data.seed.ts
+++ b/apps/backend/prisma/seeds/e2e-test-data.seed.ts
@@ -142,6 +142,8 @@ export async function seedE2ETestData() {
       pricePerToddler: 60,
       totalPrice: 26850,
       status: 'RESERVED',
+      reservationQueueDate: new Date('2026-06-20'),
+      reservationQueuePosition: 1,
       notes: 'Wesele Marek i Agnieszka - preferencje: muzyka na \u017cywo',
     },
     {
@@ -180,6 +182,8 @@ export async function seedE2ETestData() {
       pricePerToddler: 40,
       totalPrice: 9600,
       status: 'RESERVED',
+      reservationQueueDate: new Date('2026-05-10'),
+      reservationQueuePosition: 1,
       notes: 'Komunia \u015awi\u0119ta Kacpra',
     },
     {
@@ -199,6 +203,8 @@ export async function seedE2ETestData() {
       pricePerToddler: 0,
       totalPrice: 7400,
       status: 'RESERVED',
+      reservationQueueDate: new Date('2026-04-25'),
+      reservationQueuePosition: 1,
       notes: '50-te urodziny',
     },
     {

--- a/apps/backend/src/services/queue.service.ts
+++ b/apps/backend/src/services/queue.service.ts
@@ -179,7 +179,10 @@ export class QueueService {
 
   async getAllQueues(): Promise<QueueItemResponse[]> {
     const reservations = await prisma.reservation.findMany({
-      where: { status: ReservationStatus.RESERVED },
+      where: {
+        status: ReservationStatus.RESERVED,
+        reservationQueueDate: { not: null },
+      },
       include: { client: true, createdBy: { select: { id: true, firstName: true, lastName: true } } },
       orderBy: [{ reservationQueueDate: 'asc' }, { reservationQueuePosition: 'asc' }]
     });
@@ -398,7 +401,7 @@ export class QueueService {
 
   async getQueueStats(): Promise<QueueStats> {
     const reservations = await prisma.reservation.findMany({
-      where: { status: ReservationStatus.RESERVED },
+      where: { status: ReservationStatus.RESERVED, reservationQueueDate: { not: null } },
       select: { reservationQueueDate: true, guests: true, queueOrderManual: true }
     });
 

--- a/apps/frontend/app/dashboard/queue/page.tsx
+++ b/apps/frontend/app/dashboard/queue/page.tsx
@@ -68,6 +68,7 @@ export default function QueuePage() {
   }
 
   const queuesByDate = queues.reduce((acc, item) => {
+    if (!item.queueDate) return acc
     const date = format(parseISO(item.queueDate), 'yyyy-MM-dd')
     if (!acc[date]) acc[date] = []
     acc[date].push(item)
@@ -171,7 +172,7 @@ export default function QueuePage() {
     }
   }
 
-  const filteredQueues = selectedDate === 'all' ? queues : queuesByDate[selectedDate] || []
+  const filteredQueues = selectedDate === 'all' ? queues.filter(q => q.queueDate) : queuesByDate[selectedDate] || []
   const showPromoteButton = selectedDate !== 'all'
   const isDragDropDisabled = selectedDate === 'all'
 
@@ -271,7 +272,7 @@ export default function QueuePage() {
               onClick={() => setSelectedDate('all')}
               className={selectedDate === 'all' ? `bg-gradient-to-r ${accent.gradient} text-white shadow-lg` : ''}
             >
-              Wszystkie ({queues.length})
+              Wszystkie ({queues.filter(q => q.queueDate).length})
             </Button>
             {dates.map((date) => (
               <Button


### PR DESCRIPTION
## Problem
`TypeError: Cannot read properties of null (reading 'split')` on `/dashboard/queue`

E2E seed creates 3 reservations with `status: 'RESERVED'` but without `reservationQueueDate` / `reservationQueuePosition`. Backend `getAllQueues()` returns them with `queueDate: null`. Frontend calls `parseISO(null)` → `null.split()` → 💥

## Changes

### 1. Frontend — `queue/page.tsx`
- Added `if (!item.queueDate) return acc` guard in the `reduce` that groups queues by date
- Also filters `queues.filter(q => q.queueDate)` for the "all" view count

### 2. Backend — `queue.service.ts`
- `getAllQueues()`: added `reservationQueueDate: { not: null }` filter so RESERVED reservations without a queue date are excluded
- `getQueueStats()`: same filter added for consistency

### 3. E2E seed — `e2e-test-data.seed.ts`
- Added `reservationQueueDate` and `reservationQueuePosition: 1` to all 3 RESERVED reservations (indices 0, 2, 3)

## Root cause
Seed data created RESERVED reservations without queue metadata, violating the invariant that RESERVED = has queue date + position.