### PR TITLE
feat(event-types): Phase 1 — rozszerzenie backendu

### DIFF
--- a/apps/backend/src/controllers/eventType.controller.ts
+++ b/apps/backend/src/controllers/eventType.controller.ts
@@ -1,6 +1,6 @@
 /**
  * EventType Controller
- * MIGRATED: AppError + no try/catch
+ * Full CRUD + stats for event type management
  */
 
 import { Request, Response } from 'express';
@@ -10,12 +10,13 @@ import { CreateEventTypeDTO, UpdateEventTypeDTO } from '../types/eventType.types
 
 export class EventTypeController {
   async createEventType(req: Request, res: Response): Promise<void> {
-    const data: CreateEventTypeDTO = req.body;
+    const { name, description, color, isActive } = req.body;
 
-    if (!data.name) {
+    if (!name) {
       throw AppError.badRequest('Event type name is required');
     }
 
+    const data: CreateEventTypeDTO = { name, description, color, isActive };
     const eventType = await eventTypeService.createEventType(data);
 
     res.status(201).json({
@@ -25,8 +26,9 @@ export class EventTypeController {
     });
   }
 
-  async getEventTypes(_req: Request, res: Response): Promise<void> {
-    const eventTypes = await eventTypeService.getEventTypes();
+  async getEventTypes(req: Request, res: Response): Promise<void> {
+    const activeOnly = req.query.isActive === 'true';
+    const eventTypes = await eventTypeService.getEventTypes(activeOnly);
 
     res.status(200).json({
       success: true,
@@ -49,7 +51,13 @@ export class EventTypeController {
 
   async updateEventType(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
-    const data: UpdateEventTypeDTO = req.body;
+    const { name, description, color, isActive } = req.body;
+
+    const data: UpdateEventTypeDTO = {};
+    if (name !== undefined) data.name = name;
+    if (description !== undefined) data.description = description;
+    if (color !== undefined) data.color = color;
+    if (isActive !== undefined) data.isActive = isActive;
 
     const eventType = await eventTypeService.updateEventType(id, data);
 
@@ -67,6 +75,25 @@ export class EventTypeController {
     res.status(200).json({
       success: true,
       message: 'Event type deleted successfully'
+    });
+  }
+
+  async getEventTypeStats(_req: Request, res: Response): Promise<void> {
+    const stats = await eventTypeService.getEventTypeStats();
+
+    res.status(200).json({
+      success: true,
+      data: stats,
+      count: stats.length
+    });
+  }
+
+  async getPredefinedColors(_req: Request, res: Response): Promise<void> {
+    const colors = eventTypeService.getPredefinedColors();
+
+    res.status(200).json({
+      success: true,
+      data: colors
     });
   }
 }

--- a/apps/backend/src/routes/eventType.routes.ts
+++ b/apps/backend/src/routes/eventType.routes.ts
@@ -1,6 +1,6 @@
 /**
  * EventType Routes
- * MIGRATED: asyncHandler + validateUUID
+ * Full CRUD + stats + predefined colors
  */
 
 import { Router } from 'express';
@@ -11,6 +11,23 @@ import { asyncHandler } from '../middlewares/asyncHandler';
 import { validateUUID } from '../middlewares/validateUUID';
 
 const router = Router();
+
+// Stats endpoint (must be before /:id to avoid UUID conflict)
+router.get(
+  '/stats',
+  authMiddleware,
+  asyncHandler(async (req, res) => {
+    await eventTypeController.getEventTypeStats(req, res);
+  })
+);
+
+// Predefined colors for color picker
+router.get(
+  '/colors',
+  asyncHandler(async (req, res) => {
+    await eventTypeController.getPredefinedColors(req, res);
+  })
+);
 
 router.post(
   '/',

--- a/apps/backend/src/services/eventType.service.ts
+++ b/apps/backend/src/services/eventType.service.ts
@@ -4,12 +4,36 @@
  */
 
 import { prisma } from '@/lib/prisma';
-import { CreateEventTypeDTO, UpdateEventTypeDTO, EventTypeResponse } from '../types/eventType.types';
+import { CreateEventTypeDTO, UpdateEventTypeDTO, EventTypeResponse, EventTypeStatsResponse } from '../types/eventType.types';
+
+// Predefined colors for event types
+const PREDEFINED_COLORS = [
+  '#EF4444', // red
+  '#F97316', // orange
+  '#EAB308', // yellow
+  '#22C55E', // green
+  '#06B6D4', // cyan
+  '#3B82F6', // blue
+  '#8B5CF6', // violet
+  '#EC4899', // pink
+  '#F43F5E', // rose
+  '#14B8A6', // teal
+];
+
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/;
+
+function isValidColor(color: string): boolean {
+  return HEX_COLOR_REGEX.test(color);
+}
 
 export class EventTypeService {
   async createEventType(data: CreateEventTypeDTO): Promise<EventTypeResponse> {
     if (!data.name || data.name.trim().length === 0) {
       throw new Error('Event type name is required');
+    }
+
+    if (data.color && !isValidColor(data.color)) {
+      throw new Error('Invalid color format. Use hex format (e.g. #FF5733)');
     }
 
     const existingType = await prisma.eventType.findFirst({
@@ -21,23 +45,39 @@ export class EventTypeService {
     }
 
     const eventType = await prisma.eventType.create({
-      data: { name: data.name.trim() }
+      data: {
+        name: data.name.trim(),
+        description: data.description?.trim() || null,
+        color: data.color || null,
+        isActive: data.isActive !== undefined ? data.isActive : true,
+      }
     });
 
-    return eventType as any;
+    return eventType as EventTypeResponse;
   }
 
-  async getEventTypes(): Promise<EventTypeResponse[]> {
+  async getEventTypes(activeOnly: boolean = false): Promise<EventTypeResponse[]> {
+    const where = activeOnly ? { isActive: true } : {};
+
     const eventTypes = await prisma.eventType.findMany({
+      where,
       orderBy: { name: 'asc' }
     });
-    return eventTypes as any[];
+
+    return eventTypes as EventTypeResponse[];
   }
 
-  async getEventTypeById(id: string): Promise<EventTypeResponse> {
+  async getEventTypeById(id: string): Promise<EventTypeResponse & { _count: { reservations: number; menuTemplates: number } }> {
     const eventType = await prisma.eventType.findUnique({
       where: { id },
-      include: { _count: { select: { reservations: true } } }
+      include: {
+        _count: {
+          select: {
+            reservations: true,
+            menuTemplates: true,
+          }
+        }
+      }
     });
 
     if (!eventType) throw new Error('Event type not found');
@@ -48,8 +88,12 @@ export class EventTypeService {
     const existingType = await prisma.eventType.findUnique({ where: { id } });
     if (!existingType) throw new Error('Event type not found');
 
-    if (data.name && data.name.trim().length === 0) {
+    if (data.name !== undefined && data.name.trim().length === 0) {
       throw new Error('Event type name cannot be empty');
+    }
+
+    if (data.color !== undefined && data.color !== null && !isValidColor(data.color)) {
+      throw new Error('Invalid color format. Use hex format (e.g. #FF5733)');
     }
 
     if (data.name && data.name.trim() !== existingType.name) {
@@ -59,12 +103,19 @@ export class EventTypeService {
       if (typeWithSameName) throw new Error('Event type with this name already exists');
     }
 
+    const updateData: Record<string, any> = {};
+
+    if (data.name !== undefined) updateData.name = data.name.trim();
+    if (data.description !== undefined) updateData.description = data.description?.trim() || null;
+    if (data.color !== undefined) updateData.color = data.color;
+    if (data.isActive !== undefined) updateData.isActive = data.isActive;
+
     const eventType = await prisma.eventType.update({
       where: { id },
-      data: { name: data.name?.trim() }
+      data: updateData
     });
 
-    return eventType as any;
+    return eventType as EventTypeResponse;
   }
 
   async deleteEventType(id: string): Promise<void> {
@@ -79,7 +130,42 @@ export class EventTypeService {
       throw new Error(`Cannot delete event type that is used in ${reservationCount} reservation(s)`);
     }
 
+    const menuTemplateCount = await prisma.menuTemplate.count({
+      where: { eventTypeId: id }
+    });
+
+    if (menuTemplateCount > 0) {
+      throw new Error(`Cannot delete event type that has ${menuTemplateCount} menu template(s). Remove templates first.`);
+    }
+
     await prisma.eventType.delete({ where: { id } });
+  }
+
+  async getEventTypeStats(): Promise<EventTypeStatsResponse[]> {
+    const eventTypes = await prisma.eventType.findMany({
+      include: {
+        _count: {
+          select: {
+            reservations: true,
+            menuTemplates: true,
+          }
+        }
+      },
+      orderBy: { name: 'asc' }
+    });
+
+    return eventTypes.map(et => ({
+      id: et.id,
+      name: et.name,
+      color: et.color,
+      isActive: et.isActive,
+      reservationCount: et._count.reservations,
+      menuTemplateCount: et._count.menuTemplates,
+    }));
+  }
+
+  getPredefinedColors(): string[] {
+    return PREDEFINED_COLORS;
   }
 }
 

--- a/apps/backend/src/types/eventType.types.ts
+++ b/apps/backend/src/types/eventType.types.ts
@@ -5,14 +5,33 @@
 
 export interface CreateEventTypeDTO {
   name: string;
+  description?: string;
+  color?: string;
+  isActive?: boolean;
 }
 
 export interface UpdateEventTypeDTO {
   name?: string;
+  description?: string | null;
+  color?: string | null;
+  isActive?: boolean;
 }
 
 export interface EventTypeResponse {
   id: string;
   name: string;
+  description: string | null;
+  color: string | null;
+  isActive: boolean;
   createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface EventTypeStatsResponse {
+  id: string;
+  name: string;
+  color: string | null;
+  isActive: boolean;
+  reservationCount: number;
+  menuTemplateCount: number;
 }


### PR DESCRIPTION
## Faza 1: Backend Event Types — pełne DTO, service, stats

### Zmiany

#### 1. `eventType.types.ts` — rozszerzone DTO
- `CreateEventTypeDTO`: dodane `description?`, `color?`, `isActive?`
- `UpdateEventTypeDTO`: dodane `description?`, `color?`, `isActive?` (nullable)
- `EventTypeResponse`: pełna odpowiedź ze wszystkimi polami
- **Nowy** `EventTypeStatsResponse`: statystyki per typ (ile rezerwacji, ile szablonów menu)

#### 2. `eventType.service.ts` — pełna logika biznesowa
- `createEventType()` — obsługuje wszystkie pola (`name`, `description`, `color`, `isActive`)
- `getEventTypes(activeOnly?)` — opcjonalny filtr `isActive`
- `getEventTypeById()` — zwraca `_count` rezerwacji i szablonów menu
- `updateEventType()` — obsługuje częściowe aktualizacje (partial update), nullable fields
- `deleteEventType()` — blokada usuwania jeśli typ ma **rezerwacje LUB szablony menu**
- **Nowy** `getEventTypeStats()` — statystyki wszystkich typów
- **Nowy** `getPredefinedColors()` — 10 predefiniowanych kolorów hex
- Walidacja kolorów (hex: `#RGB` lub `#RRGGBB`)

#### 3. `eventType.controller.ts` — nowe endpointy
- `getEventTypeStats()` — `GET /stats`
- `getPredefinedColors()` — `GET /colors`
- `getEventTypes()` — obsługuje query param `?isActive=true`
- Create/Update — parsują nowe pola z `req.body`

#### 4. `eventType.routes.ts` — nowe trasy
- `GET /event-types/stats` — statystyki (wymaga auth)
- `GET /event-types/colors` — predefiniowane kolory
- `/stats` i `/colors` umieszczone PRZED `/:id` aby uniknąć konfliktu z UUID

### API Endpoints (kompletne)

| Method | Path | Auth | Opis |
|--------|------|------|------|
| GET | `/event-types` | ❌ | Lista typów, `?isActive=true` opcjonalnie |
| GET | `/event-types/stats` | ✅ | Statystyki per typ |
| GET | `/event-types/colors` | ❌ | Predefiniowane kolory |
| GET | `/event-types/:id` | ❌ | Szczegóły + count |
| POST | `/event-types` | ✅ Admin | Utwórz |
| PUT | `/event-types/:id` | ✅ Admin | Aktualizuj |
| DELETE | `/event-types/:id` | ✅ Admin | Usuń (jeśli brak powiązań) |

### Kolejna faza
Faza 2: Frontend API Client (`event-types-api.ts`) — create/update/delete/stats