### PR TITLE
feat(event-types): Phase 3 — UI strona główna z listą

### DIFF
--- a/apps/frontend/app/dashboard/event-types/page.tsx
+++ b/apps/frontend/app/dashboard/event-types/page.tsx
@@ -1,40 +1,187 @@
 'use client'
 
-import { Theater, Plus } from 'lucide-react'
+import { useState, useEffect, useCallback } from 'react'
+import { Plus, Search, Theater, Calendar, FileText, Eye, EyeOff, TrendingUp } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { PageLayout, PageHero, EmptyState } from '@/components/shared'
+import { Input } from '@/components/ui/input'
+import { Card } from '@/components/ui/card'
+import { useToast } from '@/hooks/use-toast'
+import { PageLayout, PageHero, StatCard, LoadingState, EmptyState } from '@/components/shared'
 import { moduleAccents } from '@/lib/design-tokens'
+import { getEventTypes, getEventTypeStats, type EventType, type EventTypeStats } from '@/lib/api/event-types-api'
+import { EventTypeCard } from '@/components/event-types/event-type-card'
 
 export default function EventTypesPage() {
+  const { toast } = useToast()
+  const [eventTypes, setEventTypes] = useState<EventType[]>([])
+  const [stats, setStats] = useState<EventTypeStats[]>([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [showInactive, setShowInactive] = useState(false)
   const accent = moduleAccents.eventTypes
+
+  const loadData = useCallback(async () => {
+    try {
+      setLoading(true)
+      const [typesData, statsData] = await Promise.all([
+        getEventTypes(!showInactive),
+        getEventTypeStats().catch(() => [] as EventTypeStats[]),
+      ])
+      setEventTypes(typesData)
+      setStats(statsData)
+    } catch (error: any) {
+      console.error('Error loading event types:', error)
+      toast({
+        title: 'B\u0142\u0105d',
+        description: 'Nie uda\u0142o si\u0119 za\u0142adowa\u0107 typ\u00f3w wydarze\u0144',
+        variant: 'destructive',
+      })
+    } finally {
+      setLoading(false)
+    }
+  }, [showInactive, toast])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
+
+  const filteredTypes = eventTypes.filter(et =>
+    et.name.toLowerCase().includes(search.toLowerCase()) ||
+    (et.description && et.description.toLowerCase().includes(search.toLowerCase()))
+  )
+
+  const getStatsForType = (id: string): EventTypeStats | undefined => {
+    return stats.find(s => s.id === id)
+  }
+
+  const totalReservations = stats.reduce((sum, s) => sum + s.reservationCount, 0)
+  const totalTemplates = stats.reduce((sum, s) => sum + s.menuTemplateCount, 0)
+  const activeTypes = eventTypes.filter(et => et.isActive).length
 
   return (
     <PageLayout>
+      {/* Hero */}
       <PageHero
         accent={accent}
-        title="Typy Wydarzeń"
+        title="Typy Wydarze\u0144"
         subtitle="Konfiguruj rodzaje imprez i ich parametry"
         icon={Theater}
         action={
-          <Button size="lg" className="bg-white text-fuchsia-600 hover:bg-white/90 shadow-xl">
+          <Button
+            size="lg"
+            className="bg-white text-fuchsia-600 hover:bg-white/90 shadow-xl"
+            onClick={() => {
+              // Phase 4: open create dialog
+              toast({ title: 'Wkr\u00f3tce', description: 'Formularz tworzenia typu — Faza 4' })
+            }}
+          >
             <Plus className="mr-2 h-5 w-5" />
             Nowy Typ
           </Button>
         }
       />
 
-      <div className="rounded-2xl bg-white dark:bg-neutral-800/80 p-8 shadow-soft border border-neutral-100 dark:border-neutral-700/50">
+      {/* Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <StatCard
+          label="Typy wydarze\u0144"
+          value={eventTypes.length}
+          subtitle="W systemie"
+          icon={Theater}
+          iconGradient="from-fuchsia-500 to-pink-500"
+          delay={0.1}
+        />
+        <StatCard
+          label="Aktywne typy"
+          value={activeTypes}
+          subtitle="Dost\u0119pne do wyboru"
+          icon={TrendingUp}
+          iconGradient="from-emerald-500 to-teal-500"
+          delay={0.2}
+        />
+        <StatCard
+          label="Rezerwacje"
+          value={totalReservations}
+          subtitle="Powi\u0105zane \u0142\u0105cznie"
+          icon={Calendar}
+          iconGradient="from-violet-500 to-purple-500"
+          delay={0.3}
+        />
+        <StatCard
+          label="Szablony menu"
+          value={totalTemplates}
+          subtitle="Przypisane \u0142\u0105cznie"
+          icon={FileText}
+          iconGradient="from-amber-500 to-orange-500"
+          delay={0.4}
+        />
+      </div>
+
+      {/* Filters */}
+      <Card>
+        <div className="p-6">
+          <div className="flex flex-col md:flex-row gap-4">
+            <div className="flex-1 relative">
+              <Search className="absolute left-4 top-1/2 transform -translate-y-1/2 text-neutral-400 h-5 w-5" />
+              <Input
+                placeholder="Szukaj typu wydarzenia..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-12 h-12 text-base"
+              />
+            </div>
+            <Button
+              size="lg"
+              variant="outline"
+              onClick={() => setShowInactive(!showInactive)}
+              className={showInactive
+                ? `bg-gradient-to-r ${accent.gradient} text-white border-transparent shadow-lg`
+                : ''
+              }
+            >
+              {showInactive ? (
+                <><EyeOff className="mr-2 h-5 w-5" />Wszystkie Typy</>
+              ) : (
+                <><Eye className="mr-2 h-5 w-5" />Tylko Aktywne</>
+              )}
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* Event Types Grid */}
+      {loading ? (
+        <LoadingState variant="skeleton" rows={6} />
+      ) : filteredTypes.length === 0 ? (
         <EmptyState
           icon={Theater}
-          title="Moduł Typów Wydarzeń"
-          description="System typów wydarzeń w przygotowaniu — wesela, komunie, urodziny, pakiety cenowe, wymagane zaliczki, szablony dokumentów."
+          title={search ? 'Nie znaleziono typ\u00f3w' : 'Brak typ\u00f3w wydarze\u0144'}
+          description={search ? 'Spr\u00f3buj u\u017cy\u0107 innego wyszukiwania' : 'Dodaj pierwszy typ wydarzenia, aby zacz\u0105\u0107'}
+          actionLabel={search ? undefined : 'Dodaj Pierwszy Typ'}
+          onAction={search ? undefined : () => {
+            toast({ title: 'Wkr\u00f3tce', description: 'Formularz tworzenia typu — Faza 4' })
+          }}
         />
-        <div className="flex justify-center mt-4">
-          <span className={`inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium ${accent.badge} ${accent.badgeText}`}>
-            ✨ Nowy moduł — Sprint 4
-          </span>
-        </div>
-      </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between">
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              Znaleziono <span className="font-bold text-neutral-900 dark:text-neutral-100">{filteredTypes.length}</span>{' '}
+              {filteredTypes.length === 1 ? 'typ' : filteredTypes.length < 5 ? 'typy' : 'typ\u00f3w'}
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filteredTypes.map((eventType) => (
+              <EventTypeCard
+                key={eventType.id}
+                eventType={eventType}
+                stats={getStatsForType(eventType.id)}
+                onUpdate={loadData}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </PageLayout>
   )
 }

--- a/apps/frontend/components/event-types/event-type-card.tsx
+++ b/apps/frontend/components/event-types/event-type-card.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import { Calendar, FileText, Pencil, Trash2, Theater, MoreHorizontal } from 'lucide-react'
+import { type EventType, type EventTypeStats } from '@/lib/api/event-types-api'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { useToast } from '@/hooks/use-toast'
+
+interface EventTypeCardProps {
+  eventType: EventType
+  stats?: EventTypeStats
+  onUpdate: () => void
+}
+
+export function EventTypeCard({ eventType, stats, onUpdate }: EventTypeCardProps) {
+  const { toast } = useToast()
+  const reservationCount = stats?.reservationCount ?? 0
+  const templateCount = stats?.menuTemplateCount ?? 0
+
+  const colorStyle = eventType.color
+    ? { backgroundColor: eventType.color }
+    : { backgroundColor: '#9CA3AF' }
+
+  return (
+    <Card className="group relative overflow-hidden transition-all duration-300 hover:shadow-lg hover:-translate-y-0.5 border-neutral-200 dark:border-neutral-700">
+      {/* Color bar at top */}
+      <div
+        className="h-2 w-full"
+        style={colorStyle}
+      />
+
+      <div className="p-6">
+        {/* Header */}
+        <div className="flex items-start justify-between mb-3">
+          <div className="flex items-center gap-3">
+            <div
+              className="flex h-10 w-10 items-center justify-center rounded-xl text-white shadow-md"
+              style={colorStyle}
+            >
+              <Theater className="h-5 w-5" />
+            </div>
+            <div>
+              <h3 className="font-semibold text-lg text-neutral-900 dark:text-neutral-100">
+                {eventType.name}
+              </h3>
+              {!eventType.isActive && (
+                <Badge variant="secondary" className="text-xs mt-0.5">
+                  Nieaktywny
+                </Badge>
+              )}
+            </div>
+          </div>
+
+          {/* Actions dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 w-8 p-0 opacity-0 group-hover:opacity-100 transition-opacity"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => {
+                  toast({ title: 'Wkr\u00f3tce', description: 'Edycja typu — Faza 4' })
+                }}
+              >
+                <Pencil className="mr-2 h-4 w-4" />
+                Edytuj
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-red-600 focus:text-red-600"
+                onClick={() => {
+                  toast({ title: 'Wkr\u00f3tce', description: 'Usuwanie typu — Faza 4' })
+                }}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Usu\u0144
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+
+        {/* Description */}
+        {eventType.description && (
+          <p className="text-sm text-neutral-500 dark:text-neutral-400 mb-4 line-clamp-2">
+            {eventType.description}
+          </p>
+        )}
+
+        {/* Stats */}
+        <div className="flex items-center gap-6 pt-4 border-t border-neutral-100 dark:border-neutral-700">
+          <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
+            <Calendar className="h-4 w-4 text-violet-500" />
+            <span className="font-medium">{reservationCount}</span>
+            <span className="text-neutral-400">{reservationCount === 1 ? 'rezerwacja' : 'rezerwacji'}</span>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-neutral-600 dark:text-neutral-300">
+            <FileText className="h-4 w-4 text-amber-500" />
+            <span className="font-medium">{templateCount}</span>
+            <span className="text-neutral-400">{templateCount === 1 ? 'szablon' : 'szablon\u00f3w'}</span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}


### PR DESCRIPTION
## Faza 3: Frontend UI — strona główna Event Types

### Zmiany

#### `event-types/page.tsx` — pełna strona (zamieniony placeholder)
- **PageHero** z ikoną Theater i przyciskiem "Nowy Typ"
- **4 StatCardy**: typy (total), aktywne, rezerwacje (łącznie), szablony menu (łącznie)
- **Wyszukiwarka** po nazwie i opisie
- **Toggle aktywne/wszystkie** z gradientowym stylem
- **Siatka kart** 3 kolumny (lg), 2 (md), 1 (sm)
- **LoadingState** (skeleton) i **EmptyState** z CTA
- Dane pobierane równolegle: `getEventTypes()` + `getEventTypeStats()`

#### `components/event-types/event-type-card.tsx` — nowy komponent
- **Kolorowy pasek** u góry karty (z `eventType.color`)
- **Ikona** z kolorem typu
- **Badge "Nieaktywny"** jeśli `isActive: false`
- **Opis** (line-clamp-2)
- **Statystyki**: liczba rezerwacji + liczba szablonów menu
- **Dropdown menu** (hover): Edytuj, Usuń — na razie toast "Faza 4"
- Hover efekt: shadow + translate

### Wzór
Zgodne z `halls/page.tsx` — ten sam układ: Hero → Stats → Filters → Grid

### Screenshot
Po deploy powinno wyglądać tak:
- 4 karty statystyk u góry
- Wyszukiwarka + toggle
- 7 kart typów (Wesele, Urodziny, Komunia, itp.) z kolorami

### Kolejna faza
Faza 4: Formularze (Create/Edit dialog, Delete dialog, Toggle aktywności)