### PR TITLE
feat(#38): Phase 4.2 auto-confirm + Phase 4.3 block cancel with paid deposits

### DIFF
--- a/apps/backend/src/controllers/reservation.controller.ts
+++ b/apps/backend/src/controllers/reservation.controller.ts
@@ -2,10 +2,12 @@
  * Reservation Controller
  * Handle HTTP requests for reservation management
  * MIGRATED: Uses AppError (no try/catch — errors forwarded by asyncHandler)
+ * Phase 4.3: Block cancellation of reservations with paid deposits
  */
 
 import { Request, Response } from 'express';
 import reservationService from '../services/reservation.service';
+import depositService from '../services/deposit.service';
 import { pdfService } from '../services/pdf.service';
 import { AppError } from '../utils/AppError';
 import { PrismaClient } from '@prisma/client';
@@ -258,6 +260,17 @@ export class ReservationController {
       throw AppError.badRequest('Status is required');
     }
 
+    // ═══ Phase 4.3: Block cancellation if reservation has paid deposits ═══
+    if (data.status === 'CANCELLED') {
+      const depositCheck = await depositService.checkPaidDepositsBeforeCancel(id);
+      if (depositCheck.hasPaidDeposits) {
+        throw AppError.badRequest(
+          `Nie można anulować rezerwacji z opłaconymi zaliczkami (${depositCheck.paidCount} zaliczek na łączną kwotę ${depositCheck.paidTotal.toFixed(2)} PLN). ` +
+          `Najpierw cofnij płatności zaliczek.`
+        );
+      }
+    }
+
     const reservation = await reservationService.updateStatus(id, data, userId);
 
     res.status(200).json({
@@ -270,6 +283,7 @@ export class ReservationController {
   /**
    * Cancel reservation
    * DELETE /api/reservations/:id
+   * Phase 4.3: Blocks if reservation has paid deposits
    */
   async cancelReservation(req: Request, res: Response): Promise<void> {
     const { id } = req.params;
@@ -277,6 +291,15 @@ export class ReservationController {
     const userId = req.user?.id;
 
     if (!userId) throw AppError.unauthorized();
+
+    // ═══ Phase 4.3: Block cancellation if reservation has paid deposits ═══
+    const depositCheck = await depositService.checkPaidDepositsBeforeCancel(id);
+    if (depositCheck.hasPaidDeposits) {
+      throw AppError.badRequest(
+        `Nie można anulować rezerwacji z opłaconymi zaliczkami (${depositCheck.paidCount} zaliczek na łączną kwotę ${depositCheck.paidTotal.toFixed(2)} PLN). ` +
+        `Najpierw cofnij płatności zaliczek.`
+      );
+    }
 
     await reservationService.cancelReservation(id, userId, reason);
 

--- a/apps/backend/src/services/deposit.service.ts
+++ b/apps/backend/src/services/deposit.service.ts
@@ -1,6 +1,8 @@
 /**
  * Deposit Service - with Audit Logging
  * Full CRUD + business logic for deposit/advance payment management
+ * Phase 4.2: Auto-confirm reservation when all deposits are paid
+ * Phase 4.3: Block cancellation of reservations with paid deposits
  */
 
 import { prisma } from '../lib/prisma';
@@ -350,7 +352,95 @@ const depositService = {
       }
     });
 
+    // ═══ Phase 4.2: Auto-confirm reservation when all deposits are paid ═══
+    if (isPaid) {
+      await depositService.checkAndAutoConfirmReservation(deposit.reservationId, userId);
+    }
+
     return updated;
+  },
+
+  /**
+   * Phase 4.2: Check if all active deposits for a reservation are paid.
+   * If yes and reservation is PENDING → auto-confirm it.
+   */
+  async checkAndAutoConfirmReservation(reservationId: string, userId: string) {
+    try {
+      const reservation = await prisma.reservation.findUnique({
+        where: { id: reservationId },
+        include: { deposits: true, client: true },
+      });
+
+      if (!reservation) return;
+      // Only auto-confirm PENDING reservations
+      if (reservation.status !== 'PENDING') return;
+
+      const activeDeposits = reservation.deposits.filter(
+        (d: any) => d.status !== 'CANCELLED'
+      );
+
+      // Need at least one active deposit
+      if (activeDeposits.length === 0) return;
+
+      const allPaid = activeDeposits.every((d: any) => d.status === 'PAID');
+
+      if (allPaid) {
+        await prisma.reservation.update({
+          where: { id: reservationId },
+          data: { status: 'CONFIRMED' },
+        });
+
+        // Create reservation history entry
+        await prisma.reservationHistory.create({
+          data: {
+            reservationId,
+            changedByUserId: userId,
+            changeType: 'STATUS_CHANGED',
+            fieldName: 'status',
+            oldValue: 'PENDING',
+            newValue: 'CONFIRMED',
+            reason: 'Automatyczne potwierdzenie — wszystkie zaliczki opłacone',
+          },
+        });
+
+        const clientName = reservation.client
+          ? `${(reservation.client as any).firstName} ${(reservation.client as any).lastName}`
+          : 'N/A';
+
+        // Audit log
+        await logChange({
+          userId,
+          action: 'AUTO_CONFIRM',
+          entityType: 'RESERVATION',
+          entityId: reservationId,
+          details: {
+            description: `Rezerwacja automatycznie potwierdzona po opłaceniu wszystkich zaliczek (${clientName})`,
+            depositsCount: activeDeposits.length,
+            totalPaid: activeDeposits.reduce((s: number, d: any) => s + Number(d.amount), 0),
+          },
+        });
+
+        logger.info(`[Deposit] Auto-confirmed reservation ${reservationId} — all ${activeDeposits.length} deposits paid`);
+      }
+    } catch (error) {
+      // Don't fail the payment operation if auto-confirm fails
+      logger.error(`[Deposit] Error in auto-confirm check for reservation ${reservationId}:`, error);
+    }
+  },
+
+  /**
+   * Phase 4.3: Check if a reservation has paid deposits (used before cancel/delete).
+   * Returns info about paid deposits for the guard check.
+   */
+  async checkPaidDepositsBeforeCancel(reservationId: string): Promise<{ hasPaidDeposits: boolean; paidCount: number; paidTotal: number }> {
+    const deposits = await prisma.deposit.findMany({
+      where: { reservationId, status: 'PAID' },
+    });
+
+    const paidCount = deposits.length;
+    const paidTotal = deposits.reduce((sum: number, d: any) => sum + Number(d.amount), 0);
+
+    return { hasPaidDeposits: paidCount > 0, paidCount, paidTotal };
   },
 
   async sendConfirmationEmail(id: string) {


### PR DESCRIPTION
## Issue #38 — Fazy 4.2 i 4.3

### Faza 4.2: Auto-confirm rezerwacji po opłaceniu wszystkich zaliczek

**Plik:** `deposit.service.ts`

Po oznaczeniu zaliczki jako opłaconej (`markAsPaid`), system automatycznie sprawdza czy **wszystkie aktywne zaliczki** danej rezerwacji mają status `PAID`. Jeśli tak, a rezerwacja jest w statusie `PENDING`, następuje:
- Automatyczna zmiana statusu na `CONFIRMED`
- Wpis w `ReservationHistory` z powodem: *"Automatyczne potwierdzenie — wszystkie zaliczki opłacone"*
- Wpis w dzienniku audytu (`audit-logger`)
- Log w konsoli serwera

**Bezpieczeństwo:** Błąd w auto-confirm NIE powoduje awarji operacji płatności — catch zapobiega propagacji.

### Faza 4.3: Blokada anulowania rezerwacji z opłaconymi zaliczkami

**Pliki:** `deposit.service.ts` + `reservation.controller.ts`

Dodano guard w **dwóch miejscach**:
1. `cancelReservation()` — endpoint `DELETE /api/reservations/:id`
2. `updateStatus()` — endpoint `PATCH /api/reservations/:id/status` (gdy `status === 'CANCELLED'`)

Przed anulowaniem system sprawdza `checkPaidDepositsBeforeCancel()`. Jeśli istnieją opłacone zaliczki, rzuca błąd:
> *"Nie można anulować rezerwacji z opłaconymi zaliczkami (X zaliczek na łączną kwotę Y PLN). Najpierw cofnij płatności zaliczek."*

### Testy manualne
- [ ] Oznacz wszystkie zaliczki jako opłacone → rezerwacja powinna zmienić się na CONFIRMED
- [ ] Spróbuj anulować rezerwację z opłaconą zaliczką → powinien pojawić się błąd
- [ ] Cofnij płatność zaliczki → anulowanie powinno być możliwe

Closes #38