### PR TITLE
fix: remove hall info from payment confirmation PDF (US-6.2)

### DIFF
--- a/apps/backend/src/services/pdf.service.ts
+++ b/apps/backend/src/services/pdf.service.ts
@@ -613,9 +613,7 @@ export class PDFService {
     doc.text(`Numer rezerwacji: ${data.reservation.id}`);
     doc.text(`Data: ${data.reservation.date}`);
     doc.text(`Godzina: ${data.reservation.startTime} - ${data.reservation.endTime}`);
-    if (data.reservation.hall) {
-      doc.text(`Sala: ${data.reservation.hall}`);
-    }
+    // US-6.2: Hall name removed from payment confirmation PDF — client should not see hall assignment
     if (data.reservation.eventType) {
       doc.text(`Typ wydarzenia: ${data.reservation.eventType}`);
     }


### PR DESCRIPTION
## Opis
Usunięcie informacji o sali (`Sala: ...`) z PDF-a "Potwierdzenie wpłaty zaliczki".

## Problem
W metodzie `buildPaymentConfirmationContent()` w sekcji **Szczegóły rezerwacji** wyświetlana była sala (`data.reservation.hall`). Klient nie powinien widzieć przypisania sali — analogicznie jak w głównym PDF rezerwacji (`buildPDFContent`), gdzie sala została usunięta wcześniej (komentarz `// US-6.2`).

## Zmiana
- **Plik:** `apps/backend/src/services/pdf.service.ts`
- **Metoda:** `buildPaymentConfirmationContent()`
- Usunięte 3 linie:
```typescript
if (data.reservation.hall) {
  doc.text(`Sala: ${data.reservation.hall}`);
}
```
- Dodany komentarz: `// US-6.2: Hall name removed from payment confirmation PDF — client should not see hall assignment`

## Testy
- Istniejące unit testy PDF service nie testują zawartości hall w payment confirmation, więc nie ma regresji.
- Zmiana jest analogiczna do już wdrożonej zmiany w `buildPDFContent()`.

## Komendy po merge
```bash
git pull origin main
docker compose up --build -d backend
```