### PR TITLE
feat: Audit Phase 1 — logChange() dla rabatów, menu i kaskadowego anulowania zaliczek

### DIFF
--- a/apps/backend/src/services/discount.service.ts
+++ b/apps/backend/src/services/discount.service.ts
@@ -2,10 +2,12 @@
  * Discount Service
  * Business logic for reservation discount management
  * Sprint 7: System Rabatów
+ * Updated: Phase 1 Audit — logChange() for ActivityLog
  */
 
 import { prisma } from '@/lib/prisma';
 import { AppError } from '../utils/AppError';
+import { logChange } from '../utils/audit-logger';
 
 const RESERVATION_INCLUDE = {
   hall: { select: { id: true, name: true, capacity: true, isWholeVenue: true } },
@@ -77,7 +79,7 @@ export class DiscountService {
       include: RESERVATION_INCLUDE,
     });
 
-    // History entry
+    // History entry (per-reservation history)
     const oldDiscount = reservation.discountType
       ? `${reservation.discountType} ${Number(reservation.discountValue)}`
       : 'Brak';
@@ -91,6 +93,31 @@ export class DiscountService {
         oldValue: oldDiscount,
         newValue: `${data.type} ${data.value}${data.type === 'PERCENTAGE' ? '%' : ' PLN'} = -${discountAmount} PLN`,
         reason: `Rabat: ${data.reason}`,
+      },
+    });
+
+    // Audit log (global ActivityLog)
+    const clientName = reservation.client
+      ? `${reservation.client.firstName} ${reservation.client.lastName}`
+      : 'N/A';
+    await logChange({
+      userId,
+      action: 'DISCOUNT_APPLIED',
+      entityType: 'RESERVATION',
+      entityId: id,
+      details: {
+        description: `Rabat ${reservation.discountType ? 'zmieniony' : 'dodany'}: ${data.type} ${data.value}${data.type === 'PERCENTAGE' ? '%' : ' PLN'} = -${discountAmount} PLN | ${clientName}`,
+        discountType: data.type,
+        discountValue: data.value,
+        discountAmount,
+        reason: data.reason,
+        oldDiscount: reservation.discountType ? {
+          type: reservation.discountType,
+          value: Number(reservation.discountValue),
+          amount: Number(reservation.discountAmount),
+        } : null,
+        priceBeforeDiscount: basePrice,
+        priceAfterDiscount: newTotalPrice,
       },
     });
 
@@ -116,6 +143,14 @@ export class DiscountService {
 
     const originalPrice = Number(reservation.priceBeforeDiscount) || Number(reservation.totalPrice);
 
+    // Save old discount info before removal
+    const removedDiscount = {
+      type: reservation.discountType,
+      value: Number(reservation.discountValue),
+      amount: Number(reservation.discountAmount),
+      reason: reservation.discountReason,
+    };
+
     const updated = await prisma.reservation.update({
       where: { id },
       data: {
@@ -129,6 +164,7 @@ export class DiscountService {
       include: RESERVATION_INCLUDE,
     });
 
+    // History entry (per-reservation history)
     await prisma.reservationHistory.create({
       data: {
         reservationId: id,
@@ -138,6 +174,22 @@ export class DiscountService {
         oldValue: `${reservation.discountType} ${Number(reservation.discountValue)}`,
         newValue: 'Brak',
         reason: `Rabat usunięty. Przywrócono cenę: ${originalPrice} PLN`,
+      },
+    });
+
+    // Audit log (global ActivityLog)
+    const clientName = reservation.client
+      ? `${reservation.client.firstName} ${reservation.client.lastName}`
+      : 'N/A';
+    await logChange({
+      userId,
+      action: 'DISCOUNT_REMOVED',
+      entityType: 'RESERVATION',
+      entityId: id,
+      details: {
+        description: `Rabat usunięty: ${removedDiscount.type} ${removedDiscount.value}${removedDiscount.type === 'PERCENTAGE' ? '%' : ' PLN'} (-${removedDiscount.amount} PLN) | ${clientName}`,
+        removedDiscount,
+        restoredPrice: originalPrice,
       },
     });
 

--- a/apps/backend/src/services/reservation.service.ts
+++ b/apps/backend/src/services/reservation.service.ts
@@ -1,6 +1,7 @@
 /**
  * Reservation Service - with full Audit Logging
  * Business logic for reservation management with advanced features
+ * Updated: Phase 1 Audit — logChange() for menu updates + cascade cancel
  */
 
 import { prisma } from '@/lib/prisma';
@@ -313,7 +314,7 @@ export class ReservationService {
 
     const reservation = await prisma.reservation.findUnique({
       where: { id: reservationId },
-      include: { menuSnapshot: true }
+      include: { menuSnapshot: true, client: true, hall: true }
     });
 
     if (!reservation) throw new Error('Reservation not found');
@@ -321,16 +322,43 @@ export class ReservationService {
       throw new Error('Cannot update menu for completed or cancelled reservations');
     }
 
+    const clientName = reservation.client
+      ? `${(reservation.client as any).firstName} ${(reservation.client as any).lastName}`
+      : 'N/A';
+    const hallName = (reservation.hall as any)?.name || 'N/A';
+
     const adults = data.adultsCount ?? reservation.adults;
     const children = data.childrenCount ?? reservation.children;
     const toddlers = data.toddlersCount ?? reservation.toddlers;
     const guests = calculateTotalGuests(adults, children, toddlers);
 
     if (data.menuPackageId === null) {
+      // Get old package name before removal
+      const oldPackageName = reservation.menuSnapshot
+        ? ((reservation.menuSnapshot as any).menuData as any)?.packageName || 'Nieznany pakiet'
+        : 'Brak';
+      const oldTotalPrice = reservation.menuSnapshot
+        ? Number((reservation.menuSnapshot as any).totalMenuPrice)
+        : 0;
+
       if (reservation.menuSnapshot) {
         await prisma.reservationMenuSnapshot.delete({ where: { id: reservation.menuSnapshot.id } });
       }
       await this.createHistoryEntry(reservationId, userId, 'MENU_REMOVED', 'menu', 'Menu package', 'None', 'Menu removed from reservation');
+
+      // Audit log — MENU_REMOVED
+      await logChange({
+        userId,
+        action: 'MENU_REMOVED',
+        entityType: 'RESERVATION',
+        entityId: reservationId,
+        details: {
+          description: `Menu usunięte z rezerwacji: ${oldPackageName} (-${oldTotalPrice} PLN) | ${clientName}`,
+          removedPackage: oldPackageName,
+          removedPrice: oldTotalPrice,
+        },
+      });
+
       return { message: 'Menu removed successfully' };
     }
 
@@ -360,6 +388,14 @@ export class ReservationService {
       const pricePerToddler = Number(menuPackage.pricePerToddler);
       const packagePrice = calculateTotalPrice(adults, children, pricePerAdult, pricePerChild, toddlers, pricePerToddler);
       const totalMenuPrice = packagePrice + optionsPrice;
+
+      // Save old info for audit
+      const oldPackageName = reservation.menuSnapshot
+        ? ((reservation.menuSnapshot as any).menuData as any)?.packageName || null
+        : null;
+      const oldTotalPrice = reservation.menuSnapshot
+        ? Number((reservation.menuSnapshot as any).totalMenuPrice)
+        : 0;
 
       const snapshotData = {
         reservationId,
@@ -394,6 +430,25 @@ export class ReservationService {
         reservation.menuSnapshot ? 'Previous package' : 'None',
         menuPackage.name, `Menu updated to: ${menuPackage.name}`
       );
+
+      // Audit log — MENU_UPDATED
+      await logChange({
+        userId,
+        action: 'MENU_UPDATED',
+        entityType: 'RESERVATION',
+        entityId: reservationId,
+        details: {
+          description: `Menu ${oldPackageName ? 'zmienione' : 'dodane'}: ${menuPackage.name} (${totalMenuPrice} PLN) | ${clientName}`,
+          oldPackage: oldPackageName,
+          newPackage: menuPackage.name,
+          oldPrice: oldTotalPrice,
+          newPrice: totalMenuPrice,
+          packagePrice,
+          optionsPrice,
+          optionsCount: selectedOptions.length,
+          guests: { adults, children, toddlers },
+        },
+      });
 
       return { message: 'Menu updated successfully', totalPrice: totalMenuPrice };
     }
@@ -900,6 +955,10 @@ export class ReservationService {
       }
     });
 
+    const totalCancelledAmount = pendingDeposits.reduce(
+      (sum: number, d: any) => sum + Number(d.amount), 0
+    );
+
     for (const deposit of pendingDeposits) {
       await tx.reservationHistory.create({
         data: {
@@ -913,6 +972,28 @@ export class ReservationService {
         }
       });
     }
+
+    // Audit log — DEPOSIT_CASCADE_CANCELLED (outside transaction, fire-and-forget)
+    // Note: logChange is non-blocking, so it's safe to call after transaction
+    setTimeout(async () => {
+      try {
+        await logChange({
+          userId,
+          action: 'DEPOSIT_CASCADE_CANCELLED',
+          entityType: 'RESERVATION',
+          entityId: reservationId,
+          details: {
+            description: `Auto-anulowano ${pendingDeposits.length} zaliczek (${totalCancelledAmount.toFixed(2)} PLN) przy anulowaniu rezerwacji`,
+            cancelledCount: pendingDeposits.length,
+            totalCancelledAmount,
+            depositIds: pendingDeposits.map((d: any) => d.id),
+            reason,
+          },
+        });
+      } catch (e) {
+        console.error('[Audit] Failed to log DEPOSIT_CASCADE_CANCELLED:', e);
+      }
+    }, 0);
 
     return pendingDeposits.length;
   }


### PR DESCRIPTION
## Opis

Rozszerzenie dziennika audytu (ActivityLog) o szczegółowe akcje w module rezerwacji, które dotychczas były logowane **tylko** w `ReservationHistory` (widoczne tylko per rezerwacja), ale **nie** w globalnym dzienniku audytu.

## Co się zmienia

### `discount.service.ts`
- ✅ **DISCOUNT_APPLIED** → `logChange()` — dodanie/zmiana rabatu teraz widoczne w dzienniku audytu
  - Loguje: typ rabatu, wartość, kwotę, powód, ceny przed/po
  - Rozróżnia dodanie nowego vs edycję istniejącego rabatu
- ✅ **DISCOUNT_REMOVED** → `logChange()` — usunięcie rabatu teraz widoczne
  - Loguje: usunięty rabat (typ, wartość, kwota), przywróconą cenę
- ➕ Dodano `import { logChange } from '../utils/audit-logger'`

### `reservation.service.ts` → `updateReservationMenu()`
- ✅ **MENU_UPDATED** → `logChange()` — zmiana/dodanie pakietu menu
  - Loguje: stary/nowy pakiet, stara/nowa cena, cena pakietu vs opcji, liczba gości
- ✅ **MENU_REMOVED** → `logChange()` — usunięcie menu z rezerwacji
  - Loguje: usunięty pakiet, cenę
- ✅ **DEPOSIT_CASCADE_CANCELLED** → `logChange()` — auto-anulowanie zaliczek przy cancelu
  - Loguje: liczbę anulowanych zaliczek, łączną kwotę, ID zaliczek
  - Implementacja: `setTimeout` (fire-and-forget, poza transakcją Prisma)

### Drobne zmiany w `updateReservationMenu()`
- Dodano `include: { client: true, hall: true }` do query rezerwacji (potrzebne dla opisu w audit logu)
- Pobieranie `oldPackageName` i `oldTotalPrice` przed nadpisaniem snapshotu

## Istniejące logi — bez zmian

Wszystkie dotychczasowe `logChange()` i `ReservationHistory` entries pozostają bez zmian.

## Nowe akcje w ActivityLog

| Akcja | Serwis | Opis |
|-------|--------|------|
| `DISCOUNT_APPLIED` | discount.service | Rabat dodany/zmieniony |
| `DISCOUNT_REMOVED` | discount.service | Rabat usunięty |
| `MENU_UPDATED` | reservation.service | Pakiet menu zmieniony/dodany |
| `MENU_REMOVED` | reservation.service | Menu usunięte z rezerwacji |
| `DEPOSIT_CASCADE_CANCELLED` | reservation.service | Auto-anulowanie zaliczek |

## Następne kroki (Phase 2+)
- Queue service (`queue.service.ts`) — 7 eventów
- Attachment service (`attachment.service.ts`) — 4 eventy
- Reservation-menu service (`reservation-menu.service.ts`) — 2 eventy