### PR TITLE
feat: Audit Phase 3 — logChange() dla załączników i menu rezerwacji

### DIFF
--- a/apps/backend/src/controllers/attachment.controller.ts
+++ b/apps/backend/src/controllers/attachment.controller.ts
@@ -1,6 +1,7 @@
 /**
  * Attachment Controller
  * Handles HTTP requests for attachment CRUD operations
+ * Updated: Phase 3 Audit — pass userId to mutating service methods
  */
 
 import { Request, Response, NextFunction } from 'express';
@@ -101,8 +102,9 @@ class AttachmentController {
     try {
       const { id } = req.params;
       const dto: UpdateAttachmentDTO = req.body;
+      const userId = (req as any).user?.id;
 
-      const updated = await attachmentService.updateAttachment(id, dto);
+      const updated = await attachmentService.updateAttachment(id, dto, userId);
 
       return res.json({ data: updated });
     } catch (error) {
@@ -117,7 +119,9 @@ class AttachmentController {
   async delete(req: Request, res: Response, next: NextFunction) {
     try {
       const { id } = req.params;
-      await attachmentService.deleteAttachment(id);
+      const userId = (req as any).user?.id;
+
+      await attachmentService.deleteAttachment(id, userId);
 
       return res.json({ message: 'Załącznik zarchiwizowany' });
     } catch (error) {
@@ -132,7 +136,9 @@ class AttachmentController {
   async archive(req: Request, res: Response, next: NextFunction) {
     try {
       const { id } = req.params;
-      const archived = await attachmentService.deleteAttachment(id);
+      const userId = (req as any).user?.id;
+
+      const archived = await attachmentService.deleteAttachment(id, userId);
 
       return res.json({ data: archived });
     } catch (error) {

--- a/apps/backend/src/services/attachment.service.ts
+++ b/apps/backend/src/services/attachment.service.ts
@@ -5,10 +5,13 @@
  * RODO redirect: When RODO is uploaded via RESERVATION or DEPOSIT,
  * the attachment is automatically stored under the CLIENT entity.
  * This ensures all RODO documents are in one place per client.
+ * 
+ * Updated: Phase 3 Audit — logChange() for all CRUD operations
  */
 
 import { prisma } from '../lib/prisma';
 import { AppError } from '../utils/AppError';
+import { logChange } from '../utils/audit-logger';
 import { CreateAttachmentDTO, UpdateAttachmentDTO, AttachmentFilters } from '../types/attachment.types';
 import { ENTITY_TYPES, EntityType, isValidCategory, STORAGE_DIRS } from '../constants/attachmentCategories';
 import { UPLOAD_BASE } from '../middlewares/upload';
@@ -98,9 +101,9 @@ class AttachmentService {
     // Validate entity exists
     await this.validateEntityExists(dto.entityType, dto.entityId);
 
-    // ═══════════════════════════════════════════════════════
+    // ═══════════════════════════════════════════════════════════
     // RODO REDIRECT: Always store RODO under CLIENT
-    // ═══════════════════════════════════════════════════════
+    // ═══════════════════════════════════════════════════════════
     let finalEntityType: EntityType = dto.entityType;
     let finalEntityId: string = dto.entityId;
 
@@ -151,6 +154,26 @@ class AttachmentService {
       `category: ${dto.category}) by user ${uploadedById}` +
       (finalEntityType !== dto.entityType ? ` [redirected from ${dto.entityType}/${dto.entityId}]` : '')
     );
+
+    // Audit log — ATTACHMENT_UPLOAD
+    await logChange({
+      userId: uploadedById,
+      action: 'ATTACHMENT_UPLOAD',
+      entityType: finalEntityType,
+      entityId: finalEntityId,
+      details: {
+        description: `Załącznik dodany: ${file.originalname} | ${dto.category} | ${finalEntityType}/${finalEntityId}`,
+        attachmentId: attachment.id,
+        originalName: file.originalname,
+        mimeType: file.mimetype,
+        sizeBytes: file.size,
+        category: dto.category,
+        label: dto.label || null,
+        redirected: finalEntityType !== dto.entityType
+          ? { from: `${dto.entityType}/${dto.entityId}`, to: `${finalEntityType}/${finalEntityId}` }
+          : null,
+      },
+    });
 
     return attachment;
   }
@@ -274,12 +297,24 @@ class AttachmentService {
   /**
    * Update attachment metadata
    */
-  async updateAttachment(id: string, dto: UpdateAttachmentDTO) {
+  async updateAttachment(id: string, dto: UpdateAttachmentDTO, userId?: string) {
     const existing = await this.getAttachmentById(id);
 
     // If changing category, validate it
     if (dto.category && !isValidCategory(existing.entityType as EntityType, dto.category)) {
       throw AppError.badRequest(`Nieprawidłowa kategoria "${dto.category}" dla typu "${existing.entityType}"`);
+    }
+
+    // Track changes for audit
+    const changes: Record<string, { old: any; new: any }> = {};
+    if (dto.label !== undefined && dto.label !== existing.label) {
+      changes.label = { old: existing.label, new: dto.label };
+    }
+    if (dto.description !== undefined && dto.description !== existing.description) {
+      changes.description = { old: existing.description, new: dto.description };
+    }
+    if (dto.category !== undefined && dto.category !== existing.category) {
+      changes.category = { old: existing.category, new: dto.category };
     }
 
     const updated = await prisma.attachment.update({
@@ -298,14 +333,30 @@ class AttachmentService {
 
     logger.info(`Attachment updated: ${id}`);
 
+    // Audit log — ATTACHMENT_UPDATE
+    if (Object.keys(changes).length > 0) {
+      await logChange({
+        userId: userId || null,
+        action: 'ATTACHMENT_UPDATE',
+        entityType: existing.entityType,
+        entityId: existing.entityId,
+        details: {
+          description: `Załącznik zaktualizowany: ${existing.originalName} | ${Object.keys(changes).join(', ')}`,
+          attachmentId: id,
+          originalName: existing.originalName,
+          changes,
+        },
+      });
+    }
+
     return updated;
   }
 
   /**
    * Soft-delete attachment (set isArchived=true)
    */
-  async deleteAttachment(id: string) {
-    await this.getAttachmentById(id); // Verify exists
+  async deleteAttachment(id: string, userId?: string) {
+    const existing = await this.getAttachmentById(id); // Verify exists
 
     const archived = await prisma.attachment.update({
       where: { id },
@@ -314,6 +365,20 @@ class AttachmentService {
 
     logger.info(`Attachment archived: ${id}`);
 
+    // Audit log — ATTACHMENT_ARCHIVE
+    await logChange({
+      userId: userId || null,
+      action: 'ATTACHMENT_ARCHIVE',
+      entityType: existing.entityType,
+      entityId: existing.entityId,
+      details: {
+        description: `Załącznik zarchiwizowany: ${existing.originalName} | ${existing.category} | ${existing.entityType}/${existing.entityId}`,
+        attachmentId: id,
+        originalName: existing.originalName,
+        category: existing.category,
+      },
+    });
+
     return archived;
   }
 
@@ -321,8 +386,18 @@ class AttachmentService {
    * Hard-delete attachment (remove file + DB record)
    * Only for admin cleanup
    */
-  async hardDeleteAttachment(id: string) {
+  async hardDeleteAttachment(id: string, userId?: string) {
     const attachment = await this.getAttachmentById(id);
+
+    // Save info for audit before deletion
+    const auditData = {
+      originalName: attachment.originalName,
+      category: attachment.category,
+      entityType: attachment.entityType,
+      entityId: attachment.entityId,
+      sizeBytes: attachment.sizeBytes,
+      storagePath: attachment.storagePath,
+    };
 
     // Delete file from disk
     const filePath = path.join(UPLOAD_BASE, attachment.storagePath);
@@ -335,6 +410,22 @@ class AttachmentService {
     await prisma.attachment.delete({ where: { id } });
 
     logger.info(`Attachment hard-deleted: ${id}`);
+
+    // Audit log — ATTACHMENT_DELETE (permanent)
+    await logChange({
+      userId: userId || null,
+      action: 'ATTACHMENT_DELETE',
+      entityType: auditData.entityType,
+      entityId: auditData.entityId,
+      details: {
+        description: `Załącznik trwale usunięty: ${auditData.originalName} | ${auditData.category} | ${auditData.entityType}/${auditData.entityId}`,
+        attachmentId: id,
+        originalName: auditData.originalName,
+        category: auditData.category,
+        sizeBytes: auditData.sizeBytes,
+        storagePath: auditData.storagePath,
+      },
+    });
   }
 
   /**

--- a/apps/backend/src/services/reservation-menu.service.ts
+++ b/apps/backend/src/services/reservation-menu.service.ts
@@ -3,10 +3,12 @@
  * Handles menu selection for reservations
  * UPDATED: Added recalculateForGuestChange for Phase C integration
  * FIX: formatMenuResponse now exposes menuTemplateId + packageId from DB columns
+ * Updated: Phase 3 Audit — logChange() for menu selection, recalculation, removal
  */
 
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { logChange } from '../utils/audit-logger';
 import {
   MenuSelectionInput,
   CategorySelectionDTO,
@@ -14,12 +16,12 @@ import {
 } from '../dto/menu-selection.dto';
 
 class ReservationMenuService {
-  async selectMenu(reservationId: string, input: MenuSelectionInput): Promise<any> {
+  async selectMenu(reservationId: string, input: MenuSelectionInput, userId?: string): Promise<any> {
     console.log('[ReservationMenu] Selecting menu for reservation:', reservationId);
 
     const reservation = await prisma.reservation.findUnique({
       where: { id: reservationId },
-      include: { eventType: true }
+      include: { eventType: true, client: true }
     });
     if (!reservation) throw new Error('Reservation not found');
 
@@ -48,6 +50,10 @@ class ReservationMenuService {
     const optionIds = selectedOptions.map(opt => opt.optionId);
     const options = optionIds.length > 0 ? await prisma.menuOption.findMany({ where: { id: { in: optionIds }, isActive: true } }) : [];
 
+    // Check if existing snapshot exists (for audit: new vs update)
+    const existingSnapshot = await prisma.reservationMenuSnapshot.findUnique({ where: { reservationId } });
+    const isNewSelection = !existingSnapshot;
+
     const snapshot = await this.buildMenuSnapshot(menuPackage, input.dishSelections || [], options, selectedOptions, adults, children, toddlers);
     const packagePrice = this.calculatePackagePrice(menuPackage, adults, children, toddlers);
     const optionsPrice = this.calculateOptionsPrice(options, selectedOptions, adults + children + toddlers);
@@ -70,6 +76,29 @@ class ReservationMenuService {
       }
     });
 
+    // Audit log — MENU_SELECTED
+    const clientName = (reservation as any).client
+      ? `${(reservation as any).client.firstName} ${(reservation as any).client.lastName}`
+      : 'N/A';
+    await logChange({
+      userId: userId || null,
+      action: 'MENU_SELECTED',
+      entityType: 'RESERVATION',
+      entityId: reservationId,
+      details: {
+        description: `Menu ${isNewSelection ? 'wybrane' : 'zmienione'}: ${menuPackage.name} (${totalMenuPrice} PLN) | ${clientName}`,
+        isNewSelection,
+        packageName: menuPackage.name,
+        templateName: menuPackage.menuTemplate.name,
+        packagePrice,
+        optionsPrice,
+        totalMenuPrice,
+        guests: { adults, children, toddlers },
+        dishSelectionsCount: input.dishSelections?.length || 0,
+        optionsCount: selectedOptions.length,
+      },
+    });
+
     return this.formatMenuResponse(menuSnapshot, adults, children, toddlers);
   }
 
@@ -85,7 +114,8 @@ class ReservationMenuService {
     reservationId: string,
     newAdults: number,
     newChildren: number,
-    newToddlers: number
+    newToddlers: number,
+    userId?: string
   ): Promise<{ totalMenuPrice: number; packagePrice: number; optionsPrice: number } | null> {
     const existingSnapshot = await prisma.reservationMenuSnapshot.findUnique({
       where: { reservationId }
@@ -95,6 +125,16 @@ class ReservationMenuService {
 
     const menuData = existingSnapshot.menuData as any as MenuSnapshotData;
     if (!menuData) return null;
+
+    // Save old values for audit
+    const oldPackagePrice = Number(existingSnapshot.packagePrice);
+    const oldOptionsPrice = Number(existingSnapshot.optionsPrice);
+    const oldTotalPrice = Number(existingSnapshot.totalMenuPrice);
+    const oldGuests = {
+      adults: existingSnapshot.adultsCount,
+      children: existingSnapshot.childrenCount,
+      toddlers: existingSnapshot.toddlersCount,
+    };
 
     // Recalculate package price using stored per-person prices
     const pricePerAdult = menuData.pricePerAdult || 0;
@@ -151,6 +191,24 @@ class ReservationMenuService {
 
     console.log(`[ReservationMenu] Recalculated prices for ${reservationId}: guests=${newTotalGuests}, package=${packagePrice}, options=${optionsPrice}, total=${totalMenuPrice}`);
 
+    // Audit log — MENU_RECALCULATED
+    if (oldTotalPrice !== totalMenuPrice) {
+      await logChange({
+        userId: userId || null,
+        action: 'MENU_RECALCULATED',
+        entityType: 'RESERVATION',
+        entityId: reservationId,
+        details: {
+          description: `Menu przeliczone (zmiana gości): ${oldTotalPrice} PLN → ${totalMenuPrice} PLN | ${menuData.packageName || 'N/A'}`,
+          packageName: menuData.packageName || null,
+          oldGuests,
+          newGuests: { adults: newAdults, children: newChildren, toddlers: newToddlers },
+          oldPrice: { package: oldPackagePrice, options: oldOptionsPrice, total: oldTotalPrice },
+          newPrice: { package: packagePrice, options: optionsPrice, total: totalMenuPrice },
+        },
+      });
+    }
+
     return { totalMenuPrice, packagePrice, optionsPrice };
   }
 
@@ -160,12 +218,35 @@ class ReservationMenuService {
     return this.formatMenuResponse(snapshot, snapshot.adultsCount, snapshot.childrenCount, snapshot.toddlersCount);
   }
 
-  async updateMenu(reservationId: string, input: MenuSelectionInput): Promise<any> {
-    return this.selectMenu(reservationId, input);
+  async updateMenu(reservationId: string, input: MenuSelectionInput, userId?: string): Promise<any> {
+    return this.selectMenu(reservationId, input, userId);
   }
 
-  async removeMenu(reservationId: string): Promise<void> {
+  async removeMenu(reservationId: string, userId?: string): Promise<void> {
+    // Get snapshot info before deletion for audit
+    const snapshot = await prisma.reservationMenuSnapshot.findUnique({
+      where: { reservationId },
+    });
+
     await prisma.reservationMenuSnapshot.delete({ where: { reservationId } });
+
+    // Audit log — MENU_DIRECT_REMOVED
+    if (snapshot) {
+      const menuData = snapshot.menuData as any;
+      await logChange({
+        userId: userId || null,
+        action: 'MENU_DIRECT_REMOVED',
+        entityType: 'RESERVATION',
+        entityId: reservationId,
+        details: {
+          description: `Menu usunięte (bezpośrednio): ${menuData?.packageName || 'N/A'} (${Number(snapshot.totalMenuPrice)} PLN)`,
+          packageName: menuData?.packageName || null,
+          totalMenuPrice: Number(snapshot.totalMenuPrice),
+          packagePrice: Number(snapshot.packagePrice),
+          optionsPrice: Number(snapshot.optionsPrice),
+        },
+      });
+    }
   }
 
   // ═══════════════════════ PRIVATE HELPERS ═══════════════════════


### PR DESCRIPTION
## Opis

Rozszerzenie dziennika audytu o operacje na **załącznikach** (4 eventy) oraz **menu rezerwacji** (3 eventy).

---

## Attachment Service — 4 eventy

| Akcja | Metoda | Logowane dane |
|-------|--------|---------------|
| `ATTACHMENT_UPLOAD` | `createAttachment()` | plik, kategoria, entityType/Id, RODO redirect |
| `ATTACHMENT_UPDATE` | `updateAttachment()` | diff zmian (label, description, category) |
| `ATTACHMENT_ARCHIVE` | `deleteAttachment()` | originalName, kategoria, entity |
| `ATTACHMENT_DELETE` | `hardDeleteAttachment()` | pełne dane + storagePath (trwałe usunięcie) |

### Zmiany w sygnaturach

```diff
- updateAttachment(id, dto)
+ updateAttachment(id, dto, userId?)

- deleteAttachment(id)
+ deleteAttachment(id, userId?)

- hardDeleteAttachment(id)
+ hardDeleteAttachment(id, userId?)
```

Wszystkie `userId` są **opcjonalne** — zachowana pełna kompatybilność wsteczna.

### Attachment Controller

- `update()` — dodano `req.user?.id` → `attachmentService.updateAttachment(id, dto, userId)`
- `delete()` — dodano `req.user?.id` → `attachmentService.deleteAttachment(id, userId)`
- `archive()` — dodano `req.user?.id` → `attachmentService.deleteAttachment(id, userId)`

### Drobne ulepszenia (attachment.service.ts)

- `updateAttachment()`: śledzenie zmian (changes diff) — label, description, category
- `ATTACHMENT_UPLOAD`: loguje RODO redirect info jeśli przekierowano z RESERVATION/DEPOSIT → CLIENT
- `ATTACHMENT_DELETE`: zapisuje dane załącznika **przed** usunięciem z dysku i DB

---

## Reservation Menu Service — 3 eventy

| Akcja | Metoda | Logowane dane |
|-------|--------|---------------|
| `MENU_SELECTED` | `selectMenu()` | pakiet, ceny, goście, nowe vs zmienione |
| `MENU_RECALCULATED` | `recalculateForGuestChange()` | stare/nowe gości + stare/nowe ceny |
| `MENU_DIRECT_REMOVED` | `removeMenu()` | pakiet, ceny (dane sprzed usunięcia) |

### Zmiany w sygnaturach

```diff
- selectMenu(reservationId, input)
+ selectMenu(reservationId, input, userId?)

- recalculateForGuestChange(reservationId, adults, children, toddlers)
+ recalculateForGuestChange(reservationId, adults, children, toddlers, userId?)

- updateMenu(reservationId, input)
+ updateMenu(reservationId, input, userId?)

- removeMenu(reservationId)
+ removeMenu(reservationId, userId?)
```

Wszystkie `userId` są **opcjonalne** — `reservation.service.ts` nadal wywołuje bez zmian (zaloguje się z `userId: null`).

### Drobne ulepszenia (reservation-menu.service.ts)

- `selectMenu()`: dodano `include: { client: true }` do reservation lookup (nazwa klienta w audit)
- `selectMenu()`: sprawdza czy to nowy wybór menu vs update (`isNewSelection` flag)
- `recalculateForGuestChange()`: loguje tylko jeśli cena się faktycznie zmieniła (`oldTotalPrice !== totalMenuPrice`)
- `removeMenu()`: pobiera snapshot **przed** usunięciem dla audit (packageName, ceny)

---

## Niezależność PRów

Ten PR jest **niezależny** od Phase 1 (#74) i Phase 2 (#75):
- Wszystkie `userId` parametry są opcjonalne
- Nie modyfikuje `reservation.service.ts` (uniknięcie konfliktu z Phase 1)
- Po merge’u Phase 1, można zaktualizować wywołanie `recalculateForGuestChange()` w `reservation.service.ts` żeby przekazywać `userId`

## Pokrycie audytu po Phase 1–3

| Serwis | Eventy |
|--------|--------|
| `reservation.service.ts` | 7 (CREATE, UPDATE, STATUS_CHANGE, MENU_UPDATE, MENU_REMOVE, PAYMENT_UPDATE, DELETE) |
| `queue.service.ts` | 8 (ADD, UPDATE, SWAP, MOVE, REORDER, REBUILD, PROMOTE, AUTO_CANCEL) |
| `attachment.service.ts` | 4 (UPLOAD, UPDATE, ARCHIVE, DELETE) |
| `reservation-menu.service.ts` | 3 (SELECTED, RECALCULATED, DIRECT_REMOVED) |
| **Łącznie** | **22 eventy** |