### PR TITLE
feat: Sprint 10B Phase 1 — CSS Variables + next-themes + Persistent Dark Mode

### DIFF
--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -4,7 +4,7 @@
 
 @layer base {
   :root {
-    /* === Synced with tailwind.config.ts Indigo palette === */
+    /* === Core — Synced with tailwind.config.ts Indigo palette === */
     --background: 0 0% 100%;
     --foreground: 222 47% 11%;
 
@@ -39,16 +39,40 @@
     /* === Premium Design Tokens === */
     --shadow-color: 220 40% 2%;
     --premium-glow: 239 84% 67%;
+
+    /* === Semantic Status Colors === */
+    --success: 160 84% 39%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 50%;
+    --warning-foreground: 0 0% 100%;
+    --info: 217 91% 60%;
+    --info-foreground: 0 0% 100%;
+
+    /* === Sidebar === */
+    --sidebar-background: 0 0% 100%;
+    --sidebar-foreground: 222 47% 11%;
+    --sidebar-border: 214 32% 91%;
+    --sidebar-accent: 210 40% 96%;
+    --sidebar-accent-foreground: 222 47% 11%;
+
+    /* === Chart Colors (Data Visualization) === */
+    --chart-1: 239 84% 67%;
+    --chart-2: 160 84% 39%;
+    --chart-3: 38 92% 50%;
+    --chart-4: 270 50% 60%;
+    --chart-5: 0 84% 60%;
   }
 
   .dark {
+    /* === Core Dark === */
     --background: 224 71% 4%;
     --foreground: 213 31% 91%;
 
-    --card: 224 71% 4%;
+    /* Card slightly lighter than background for visual separation */
+    --card: 222 47% 7%;
     --card-foreground: 213 31% 91%;
 
-    --popover: 224 71% 4%;
+    --popover: 222 47% 7%;
     --popover-foreground: 213 31% 91%;
 
     --primary: 239 84% 67%;
@@ -69,6 +93,32 @@
     --border: 216 34% 17%;
     --input: 216 34% 17%;
     --ring: 239 84% 67%;
+
+    /* === Premium Design Tokens (Dark) === */
+    --shadow-color: 0 0% 0%;
+    --premium-glow: 239 84% 67%;
+
+    /* === Semantic Status Colors (Dark — slightly brighter for readability) === */
+    --success: 160 73% 46%;
+    --success-foreground: 0 0% 100%;
+    --warning: 38 92% 56%;
+    --warning-foreground: 0 0% 0%;
+    --info: 217 91% 65%;
+    --info-foreground: 0 0% 100%;
+
+    /* === Sidebar (Dark) === */
+    --sidebar-background: 224 71% 4%;
+    --sidebar-foreground: 213 31% 91%;
+    --sidebar-border: 216 34% 17%;
+    --sidebar-accent: 223 47% 11%;
+    --sidebar-accent-foreground: 213 31% 91%;
+
+    /* === Chart Colors (Dark — brighter for contrast) === */
+    --chart-1: 239 84% 72%;
+    --chart-2: 160 73% 50%;
+    --chart-3: 38 92% 60%;
+    --chart-4: 270 50% 65%;
+    --chart-5: 0 84% 65%;
   }
 }
 

--- a/apps/frontend/app/providers.tsx
+++ b/apps/frontend/app/providers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from 'next-themes'
 import { useState } from 'react'
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -16,5 +17,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
       })
   )
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="light"
+      enableSystem
+      disableTransitionOnChange
+    >
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
 }

--- a/apps/frontend/components/layout/Header.tsx
+++ b/apps/frontend/components/layout/Header.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { useTheme } from 'next-themes'
 import { Bell, Search, Moon, Sun, Menu } from 'lucide-react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/lib/utils'
@@ -18,7 +19,8 @@ interface HeaderProps {
 
 export default function Header({ user, onMenuClick }: HeaderProps) {
   const router = useRouter()
-  const [isDark, setIsDark] = useState(false)
+  const { resolvedTheme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
   const [showNotifications, setShowNotifications] = useState(false)
   const [notifications] = useState([
     { id: 1, title: 'Nowa rezerwacja', message: 'Jan Kowalski - Wesele 15.02', time: '5 min temu', unread: true, link: '/dashboard/reservations' },
@@ -27,10 +29,13 @@ export default function Header({ user, onMenuClick }: HeaderProps) {
   ])
 
   const unreadCount = notifications.filter(n => n.unread).length
+  const isDark = resolvedTheme === 'dark'
+
+  // Prevent hydration mismatch — render theme icon only after client mount
+  useEffect(() => setMounted(true), [])
 
   const toggleTheme = () => {
-    setIsDark(!isDark)
-    document.documentElement.classList.toggle('dark')
+    setTheme(isDark ? 'light' : 'dark')
   }
 
   const handleNotificationClick = (notif: typeof notifications[0]) => {
@@ -84,35 +89,39 @@ export default function Header({ user, onMenuClick }: HeaderProps) {
             </kbd>
           </button>
 
-          {/* Theme Toggle */}
+          {/* Theme Toggle — persistent via next-themes */}
           <button
             onClick={toggleTheme}
             className="rounded-xl bg-neutral-100 dark:bg-neutral-800/80 p-2.5 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-all duration-200 hover:-translate-y-0.5"
-            aria-label="Przełącz motyw"
+            aria-label={isDark ? 'Przełącz na jasny motyw' : 'Przełącz na ciemny motyw'}
           >
-            <AnimatePresence mode="wait">
-              {isDark ? (
-                <motion.div
-                  key="sun"
-                  initial={{ rotate: -90, opacity: 0, scale: 0.5 }}
-                  animate={{ rotate: 0, opacity: 1, scale: 1 }}
-                  exit={{ rotate: 90, opacity: 0, scale: 0.5 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <Sun className="h-[18px] w-[18px] text-amber-500" />
-                </motion.div>
-              ) : (
-                <motion.div
-                  key="moon"
-                  initial={{ rotate: 90, opacity: 0, scale: 0.5 }}
-                  animate={{ rotate: 0, opacity: 1, scale: 1 }}
-                  exit={{ rotate: -90, opacity: 0, scale: 0.5 }}
-                  transition={{ duration: 0.2 }}
-                >
-                  <Moon className="h-[18px] w-[18px] text-neutral-600 dark:text-neutral-400" />
-                </motion.div>
-              )}
-            </AnimatePresence>
+            {mounted ? (
+              <AnimatePresence mode="wait">
+                {isDark ? (
+                  <motion.div
+                    key="sun"
+                    initial={{ rotate: -90, opacity: 0, scale: 0.5 }}
+                    animate={{ rotate: 0, opacity: 1, scale: 1 }}
+                    exit={{ rotate: 90, opacity: 0, scale: 0.5 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <Sun className="h-[18px] w-[18px] text-amber-500" />
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="moon"
+                    initial={{ rotate: 90, opacity: 0, scale: 0.5 }}
+                    animate={{ rotate: 0, opacity: 1, scale: 1 }}
+                    exit={{ rotate: -90, opacity: 0, scale: 0.5 }}
+                    transition={{ duration: 0.2 }}
+                  >
+                    <Moon className="h-[18px] w-[18px] text-neutral-600 dark:text-neutral-400" />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            ) : (
+              <div className="h-[18px] w-[18px]" />
+            )}
           </button>
 
           {/* Notifications */}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -35,6 +35,7 @@
     "tailwind-merge": "^2.2.1",
     "sonner": "^1.3.1",
     "zustand": "^4.5.0",
+    "next-themes": "^0.4.4",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
## Sprint 10B — Faza 1: Dark Mode Foundation

### US-10B.1: Enhanced CSS Variables System
- ✅ Dodano **semantic status colors** (`--success`, `--warning`, `--info`) dla light/dark
- ✅ Dodano **sidebar-specific variables** (`--sidebar-background`, `--sidebar-foreground`, `--sidebar-border`, `--sidebar-accent`)
- ✅ Dodano **5 chart color variables** dla data visualization
- ✅ **Fix**: dark `--card` i `--popover` mają 7% lightness (zamiast 4% = identyczne z background) — karty teraz wyróżniają się od tła
- ✅ Dodano `--shadow-color` i `--premium-glow` dark variants

### US-10B.2: ThemeProvider + Persistent Toggle
- ✅ Dodano `next-themes@^0.4.4` do dependencies
- ✅ `providers.tsx`: wrappuje app w `ThemeProvider` (`attribute="class"`, `defaultTheme="light"`, `enableSystem`)
- ✅ `Header.tsx`: zamieniono `useState(false)` + `classList.toggle('dark')` na `useTheme()` z next-themes
- ✅ Dodano `mounted` guard — zapobiega hydration mismatch (SSR)
- ✅ **Theme persists** — zapisuje się w localStorage, przeżywa refresh
- ✅ Dynamiczny `aria-label` ("Przełącz na jasny/ciemny motyw")

### Files Changed (4)
| File | Change |
|------|--------|
| `apps/frontend/package.json` | +`next-themes` |
| `apps/frontend/app/providers.tsx` | +ThemeProvider wrapper |
| `apps/frontend/app/globals.css` | +sidebar/chart/status CSS vars, fix dark card |
| `apps/frontend/components/layout/Header.tsx` | `useTheme()` zamiast local state |

### Jak działa
1. `ThemeProvider` (next-themes) zarządza klasą `.dark` na `<html>`
2. Toggle w Header wywołuje `setTheme('dark'|'light')`
3. Wybór zapisany w `localStorage` → persistent
4. `enableSystem` = respektuje preferencje OS
5. `disableTransitionOnChange` = brak flash przy zmianie

### Po merge (komendy serwer)
```bash
cd /home/kamil/rezerwacje
git checkout main && git pull origin main
docker compose exec frontend npm install
docker compose up --build -d frontend
docker logs -f rezerwacje-web
```