### PR TITLE
fix: Add /app/node_modules anonymous volume — prevent bind mount override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - backend
     volumes:
       - ./apps/frontend:/app
+      - /app/node_modules
       - /app/.next
     networks:
       - rezerwacje-network


### PR DESCRIPTION
## Problem

`docker-compose.yml` mountuje `./apps/frontend:/app` jako bind mount. To **nadpisuje cały `/app`** w kontenerze (w tym `node_modules` zainstalowane w obrazie) plikami z hosta.

Host ma `node_modules` zainstalowane z `NODE_ENV=production` (odziedziczone z docker-compose env), więc **brakuje devDependencies** (tailwindcss, autoprefixer, typescript, postcss, etc.).

Stąd błędy:
```
Cannot find module 'tailwindcss'
Can't resolve '@/components/ui/button'
```

Drugi błąd (`@/components/ui/button`) występuje bo webpack wymaga tailwindcss do przetworzenia CSS — jak ten krok failuje, kolejne moduły też nie są rozpoznawane.

## Fix

Dodano `/app/node_modules` jako **anonymous volume** w docker-compose.yml:
```yaml
volumes:
  - ./apps/frontend:/app
  - /app/node_modules    # ← NEW: chroni container's node_modules
  - /app/.next
```

To standardowy Docker pattern dla Node.js z bind mounts:
1. Bind mount nadpisuje `/app` plikami z hosta
2. Anonymous volume chroni `/app/node_modules` — używa wersji z obrazu (pełne deps)
3. Anonymous volume chroni `/app/.next` — cache buildu

## Deploy
```bash
cd /home/kamil/rezerwacje
git checkout main && git pull origin main
docker compose down -v       # UWAGA: -v usuwa anonymous volumes (wymagane!)
docker compose up --build -d
docker logs -f rezerwacje-web
```

⚠️ **`-v` jest kluczowe** — bez tego Docker użyje starego anonymous volume ze zepsutym node_modules.