### PR TITLE
fix(#105): cascadeCancelDeposits — VarChar(20) overflow + dueDate type mismatch

### DIFF
--- a/apps/backend/src/services/reservation.service.ts
+++ b/apps/backend/src/services/reservation.service.ts
@@ -268,7 +268,7 @@ export class ReservationService {
           reservationId: reservation.id,
           amount: depositAmount,
           remainingAmount: depositAmount,
-          dueDate: new Date(depositData.dueDate),
+          dueDate: new Date(depositData.dueDate).toISOString().split('T')[0],
           paid: depositData.paid || false,
           status: depositData.paid ? 'PAID' : 'PENDING',
           paymentMethod: sanitizeString(depositData.paymentMethod),
@@ -804,7 +804,7 @@ export class ReservationService {
       entityType: 'RESERVATION',
       entityId: id,
       details: {
-        description: `Zmiana statusu rezerwacji: ${existingReservation.status} \u2192 ${data.status}`,
+        description: `Zmiana statusu rezerwacji: ${existingReservation.status} → ${data.status}`,
         oldStatus: existingReservation.status,
         newStatus: data.status,
         reason: data.reason
@@ -971,7 +971,7 @@ export class ReservationService {
         data: {
           reservationId,
           changedByUserId: userId,
-          changeType: 'DEPOSIT_CASCADE_CANCELLED',
+          changeType: 'DEPOSIT_CANCELLED',
           fieldName: 'deposit',
           oldValue: deposit.status,
           newValue: 'CANCELLED',
@@ -980,13 +980,13 @@ export class ReservationService {
       });
     }
 
-    // Audit log — DEPOSIT_CASCADE_CANCELLED (outside transaction, fire-and-forget)
+    // Audit log — DEPOSIT_CANCELLED (outside transaction, fire-and-forget)
     /* istanbul ignore next */
     setTimeout(async () => {
       try {
         await logChange({
           userId,
-          action: 'DEPOSIT_CASCADE_CANCELLED',
+          action: 'DEPOSIT_CANCELLED',
           entityType: 'RESERVATION',
           entityId: reservationId,
           details: {
@@ -998,7 +998,7 @@ export class ReservationService {
           },
         });
       } catch (e) {
-        console.error('[Audit] Failed to log DEPOSIT_CASCADE_CANCELLED:', e);
+        console.error('[Audit] Failed to log DEPOSIT_CANCELLED:', e);
       }
     }, 0);
 
@@ -1049,7 +1049,7 @@ export class ReservationService {
         /* istanbul ignore next -- hall always included */
         const hallName = (conflict as any).hall?.name || 'inna sala';
         throw new Error(
-          `Nie można zarezerwować całego obiektu \u2014 sala "${hallName}" ma już rezerwację w tym terminie (${clientName}).`
+          `Nie można zarezerwować całego obiektu — sala "${hallName}" ma już rezerwację w tym terminie (${clientName}).`
         );
       }
     } else {
@@ -1072,7 +1072,7 @@ export class ReservationService {
           ? `${conflict.client.firstName} ${conflict.client.lastName}`
           : 'nieznany klient';
         throw new Error(
-          `Nie można zarezerwować tej sali \u2014 cały obiekt jest już zarezerwowany w tym terminie (${clientName}).`
+          `Nie można zarezerwować tej sali — cały obiekt jest już zarezerwowany w tym terminie (${clientName}).`
         );
       }
     }
@@ -1081,7 +1081,7 @@ export class ReservationService {
   private async validateUserId(userId: string): Promise<void> {
     const user = await prisma.user.findUnique({ where: { id: userId } });
     if (!user) {
-      throw new AppError(401, 'Sesja wygasła lub użytkownik nie istnieje \u2014 wyloguj się i zaloguj ponownie');
+      throw new AppError(401, 'Sesja wygasła lub użytkownik nie istnieje — wyloguj się i zaloguj ponownie');
     }
   }
 

--- a/apps/backend/src/tests/integration/reservations.api.test.ts
+++ b/apps/backend/src/tests/integration/reservations.api.test.ts
@@ -776,7 +776,7 @@ describe('Reservations API — /api/reservations', () => {
       expect([400, 422, 500]).toContain(res.status);
     });
 
-    it('should attempt cascade cancel of deposits when cancelling reservation', async () => {
+    it('should cascade cancel deposits when cancelling reservation', async () => {
       const reservation = await createReservationInDb({ status: 'CONFIRMED' });
 
       // Create a PENDING deposit — dueDate is String (VarChar(10)), not DateTime
@@ -795,15 +795,12 @@ describe('Reservations API — /api/reservations', () => {
         .set(adminAuth())
         .send({ status: 'CANCELLED', reason: 'Test cascade cancel with deposit' });
 
-      // 200 = success with cascade, 500 = cascade error in $transaction
-      expect([200, 500]).toContain(res.status);
+      expect(res.status).toBe(200);
 
-      if (res.status === 200) {
-        const deposits = await prismaTest.deposit.findMany({
-          where: { reservationId: reservation.id },
-        });
-        expect(deposits[0]?.status).toBe('CANCELLED');
-      }
+      const deposits = await prismaTest.deposit.findMany({
+        where: { reservationId: reservation.id },
+      });
+      expect(deposits[0]?.status).toBe('CANCELLED');
     });
 
     it('should return 404 for non-existent reservation', async () => {
@@ -1028,7 +1025,7 @@ describe('Reservations API — /api/reservations', () => {
       expect([400, 409, 500]).toContain(res.status);
     });
 
-    it('should attempt cascade cancel of deposits on delete', async () => {
+    it('should cascade cancel deposits on delete', async () => {
       const reservation = await createReservationInDb({ status: 'PENDING' });
 
       // dueDate is String (VarChar(10)), not DateTime
@@ -1046,16 +1043,13 @@ describe('Reservations API — /api/reservations', () => {
         .delete(`/api/reservations/${reservation.id}`)
         .set(adminAuth());
 
-      // 200/204 = cancelled with cascade, 500 = cascade error in $transaction
-      expect([200, 204, 500]).toContain(res.status);
+      expect([200, 204]).toContain(res.status);
 
-      if (res.status !== 500) {
-        const deposits = await prismaTest.deposit.findMany({
-          where: { reservationId: reservation.id },
-        });
-        if (deposits.length > 0) {
-          expect(deposits[0].status).toBe('CANCELLED');
-        }
+      const deposits = await prismaTest.deposit.findMany({
+        where: { reservationId: reservation.id },
+      });
+      if (deposits.length > 0) {
+        expect(deposits[0].status).toBe('CANCELLED');
       }
     });
 


### PR DESCRIPTION
## Problem

Przy anulowaniu rezerwacji z powiązanymi depozytami endpoint zwracał **500** zamiast 200.

Fixes #105

## Root Cause Analysis

### Bug 1: `changeType` overflow — VarChar(20)

W `cascadeCancelDeposits()` wartość `'DEPOSIT_CASCADE_CANCELLED'` ma **26 znaków**, podczas gdy pole `ReservationHistory.changeType` w schemacie Prisma to `String @db.VarChar(20)`.

PostgreSQL rzucał:
```
ERROR: value too long for type character varying(20)
```

To powodowało rollback `$transaction` → HTTP 500.

### Bug 2: `dueDate` type mismatch

W `createReservation()` depozyt był tworzony z:
```typescript
dueDate: new Date(depositData.dueDate)  // ← Date object
```

Ale schemat Prisma definiuje `dueDate` jako `String @db.VarChar(10)` — oczekiwany format to `"YYYY-MM-DD"`.

## Fix

| Plik | Zmiana |
|------|--------|
| `reservation.service.ts` | `'DEPOSIT_CASCADE_CANCELLED'` → `'DEPOSIT_CANCELLED'` (17 znaków ≤ 20) |
| `reservation.service.ts` | `new Date(dueDate)` → `new Date(dueDate).toISOString().split('T')[0]` |
| `reservations.api.test.ts` | Usunięto workaround `[200, 500]` — testy teraz wymagają 200 |

## Tests

- `should cascade cancel deposits when cancelling reservation` — teraz `expect(res.status).toBe(200)` zamiast `expect([200, 500])`
- `should cascade cancel deposits on delete` — teraz `expect([200, 204])` zamiast `expect([200, 204, 500])`
- Asercje na status depozytów są bezwarunkowe (bez `if (res.status !== 500)`)