### PR TITLE
chore: add .env examples + password change CLI

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,48 @@
+# ============================================
+# Development Environment Variables
+# ============================================
+# Copy this file to .env.dev and fill in your values:
+#   cp .env.dev.example .env.dev
+# ============================================
+
+NODE_ENV=development
+
+# Database
+DB_USER=rezerwacje_dev
+DB_PASSWORD=your_dev_password_here
+DB_NAME=rezerwacje_dev
+DB_PORT=5434
+
+# Backend API
+API_PORT=4001
+JWT_SECRET=your_dev_jwt_secret_here
+JWT_EXPIRES_IN=7d
+
+# Frontend
+WEB_PORT=4000
+NEXT_PUBLIC_API_URL=http://localhost:4001
+NEXT_PUBLIC_APP_NAME=Gościniec Rodzinny (DEV)
+
+# Redis
+REDIS_PORT=6380
+
+# Email (SMTP) — for dev you can use Mailtrap or similar
+SMTP_HOST=smtp.mailtrap.io
+SMTP_PORT=587
+SMTP_USER=your_smtp_user
+SMTP_PASS=your_smtp_password
+SMTP_FROM=dev@example.com
+
+# Logging
+LOG_LEVEL=debug
+
+# Restaurant info
+RESTAURANT_NAME=Gościniec Rodzinny
+RESTAURANT_ADDRESS=ul. Przykładowa 1, 00-000 Miasto
+RESTAURANT_PHONE=+48 000 000 000
+RESTAURANT_EMAIL=kontakt@example.com
+RESTAURANT_WEBSITE=https://example.com
+RESTAURANT_NIP=0000000000
+
+# CORS
+CORS_ORIGIN=http://localhost:4000

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,50 @@
+# ============================================
+# Production Environment Variables
+# ============================================
+# Copy this file to .env.prod and fill in your values:
+#   cp .env.prod.example .env.prod
+#
+# ⚠️  NEVER commit .env.prod to version control!
+# ============================================
+
+NODE_ENV=production
+
+# Database
+DB_USER=rezerwacje
+DB_PASSWORD=CHANGE_ME_strong_random_password
+DB_NAME=rezerwacje
+DB_PORT=5432
+
+# Backend API
+API_PORT=3001
+JWT_SECRET=CHANGE_ME_run_openssl_rand_base64_64
+JWT_EXPIRES_IN=24h
+
+# Frontend
+WEB_PORT=3000
+NEXT_PUBLIC_API_URL=https://your-domain.pl/api
+NEXT_PUBLIC_APP_NAME=Gościniec Rodzinny
+
+# Redis
+REDIS_PORT=6379
+
+# Email (SMTP) — fill with real SMTP provider credentials
+SMTP_HOST=smtp.your-provider.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_user
+SMTP_PASS=CHANGE_ME_smtp_password
+SMTP_FROM=rezerwacje@your-domain.pl
+
+# Logging
+LOG_LEVEL=warn
+
+# Restaurant info
+RESTAURANT_NAME=Gościniec Rodzinny
+RESTAURANT_ADDRESS=Twój adres
+RESTAURANT_PHONE=+48 000 000 000
+RESTAURANT_EMAIL=kontakt@your-domain.pl
+RESTAURANT_WEBSITE=https://your-domain.pl
+RESTAURANT_NIP=0000000000
+
+# CORS
+CORS_ORIGIN=https://your-domain.pl

--- a/apps/backend/prisma/change-password.ts
+++ b/apps/backend/prisma/change-password.ts
@@ -1,0 +1,125 @@
+/**
+ * CLI tool to change a user's password.
+ *
+ * Usage:
+ *   npx ts-node apps/backend/prisma/change-password.ts \
+ *     --email admin@gosciniecrodzinny.pl \
+ *     --password 'YourNewStrongPassword!2026'
+ *
+ * Or via environment variable:
+ *   NEW_PASSWORD='YourNewStrongPassword!2026' \
+ *   npx ts-node apps/backend/prisma/change-password.ts \
+ *     --email admin@gosciniecrodzinny.pl
+ *
+ * Password requirements:
+ *   - Minimum 12 characters
+ *   - At least one uppercase letter
+ *   - At least one lowercase letter
+ *   - At least one digit
+ *   - At least one special character (!@#$%^&*)
+ */
+
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+interface PasswordValidation {
+  valid: boolean;
+  errors: string[];
+}
+
+function validatePassword(password: string): PasswordValidation {
+  const errors: string[] = [];
+
+  if (password.length < 12) {
+    errors.push('Password must be at least 12 characters long');
+  }
+  if (!/[A-Z]/.test(password)) {
+    errors.push('Password must contain at least one uppercase letter');
+  }
+  if (!/[a-z]/.test(password)) {
+    errors.push('Password must contain at least one lowercase letter');
+  }
+  if (!/[0-9]/.test(password)) {
+    errors.push('Password must contain at least one digit');
+  }
+  if (!/[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password)) {
+    errors.push('Password must contain at least one special character');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function parseArgs(): { email: string; password: string } {
+  const args = process.argv.slice(2);
+  let email = '';
+  let password = process.env.NEW_PASSWORD || '';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--email' && args[i + 1]) {
+      email = args[i + 1];
+      i++;
+    } else if (args[i] === '--password' && args[i + 1]) {
+      password = args[i + 1];
+      i++;
+    }
+  }
+
+  if (!email) {
+    console.error('\n❌ Missing required --email parameter');
+    console.error('\nUsage:');
+    console.error(
+      "  npx ts-node apps/backend/prisma/change-password.ts --email user@example.com --password 'NewPassword123!'"
+    );
+    process.exit(1);
+  }
+
+  if (!password) {
+    console.error('\n❌ Missing password. Provide via --password flag or NEW_PASSWORD env var');
+    process.exit(1);
+  }
+
+  return { email, password };
+}
+
+async function main(): Promise<void> {
+  const { email, password } = parseArgs();
+
+  console.log(`\n🔐 Changing password for: ${email}`);
+
+  // Validate password strength
+  const validation = validatePassword(password);
+  if (!validation.valid) {
+    console.error('\n❌ Password does not meet requirements:');
+    validation.errors.forEach((err) => console.error(`   • ${err}`));
+    process.exit(1);
+  }
+
+  // Check if user exists
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    console.error(`\n❌ User with email "${email}" not found`);
+    process.exit(1);
+  }
+
+  // Hash and update
+  const hashedPassword = await bcrypt.hash(password, 12);
+  await prisma.user.update({
+    where: { email },
+    data: { password: hashedPassword },
+  });
+
+  console.log('✅ Password changed successfully');
+  console.log(`   User: ${user.email}`);
+  console.log(`   Time: ${new Date().toISOString()}`);
+}
+
+main()
+  .catch((error) => {
+    console.error('\n❌ Failed to change password:', error.message);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Faza 2 — Narzędzia deweloperskie

### Co dodaje ten PR?

#### 1. `.env.dev.example`
Szablon dla środowiska deweloperskiego z domyślnymi portami (4000/4001) i placeholderami.

```bash
# Użycie:
cp .env.dev.example .env.dev
# Wypełnij wartości i odpal: make dev
```

#### 2. `.env.prod.example`
Szablon produkcyjny z komentarzami i ostrzeżeniami. Zawiera:
- Wszystkie wymagane zmienne
- Instrukcje generowania JWT_SECRET
- Przypomnienie o silnych hasłach

```bash
# Użycie:
cp .env.prod.example .env.prod
# Wypełnij wartości i odpal: make prod
```

#### 3. `apps/backend/prisma/change-password.ts`
Skrypt CLI do zmiany hasła użytkownika z walidacją:
- Min. 12 znaków
- Wielka litera, mała litera, cyfra, znak specjalny

```bash
# Użycie:
npx ts-node apps/backend/prisma/change-password.ts \
  --email admin@gosciniecrodzinny.pl \
  --password 'NoweHaslo123!'
```

### Kontekst
Kontynuacja audytu bezpieczeństwa z PR #1 (`security/credentials-audit`).

`.env.dev` i `.env.prod` są już w `.gitignore` — te pliki `.example` służą jako dokumentacja struktury.