### PR TITLE
feat(catering): frontend Phase 1 — types, hooks, templates page, nav (#150)

### DIFF
--- a/apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateForm.tsx
+++ b/apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateForm.tsx
@@ -1,0 +1,221 @@
+// apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateForm.tsx
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2 } from 'lucide-react';
+import {
+  useCreateCateringTemplate,
+  useUpdateCateringTemplate,
+} from '@/hooks/use-catering';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import type { CateringTemplate } from '@/types/catering.types';
+
+const schema = z.object({
+  name: z.string().min(1, 'Nazwa jest wymagana').max(100),
+  slug: z
+    .string()
+    .min(1, 'Slug jest wymagany')
+    .max(100)
+    .regex(/^[a-z0-9-]+$/, 'Tylko małe litery, cyfry i myślniki'),
+  description: z.string().max(500).optional(),
+  imageUrl: z.string().url('Nieprawidłowy URL').optional().or(z.literal('')),
+  isActive: z.boolean(),
+  displayOrder: z.coerce.number().int().min(0),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  template?: CateringTemplate | null;
+  onClose: () => void;
+}
+
+export function CateringTemplateForm({ template, onClose }: Props) {
+  const isEdit = !!template;
+  const createMutation = useCreateCateringTemplate();
+  const updateMutation = useUpdateCateringTemplate();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: '',
+      slug: '',
+      description: '',
+      imageUrl: '',
+      isActive: true,
+      displayOrder: 0,
+    },
+  });
+
+  useEffect(() => {
+    if (template) {
+      form.reset({
+        name: template.name,
+        slug: template.slug,
+        description: template.description ?? '',
+        imageUrl: template.imageUrl ?? '',
+        isActive: template.isActive,
+        displayOrder: template.displayOrder,
+      });
+    }
+  }, [template, form]);
+
+  // Auto-generate slug from name (only on create)
+  const watchName = form.watch('name');
+  useEffect(() => {
+    if (isEdit) return;
+    const slug = watchName
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    form.setValue('slug', slug, { shouldValidate: false });
+  }, [watchName, isEdit, form]);
+
+  const onSubmit = async (values: FormValues) => {
+    const payload = {
+      ...values,
+      description: values.description || undefined,
+      imageUrl: values.imageUrl || undefined,
+    };
+
+    if (isEdit && template) {
+      await updateMutation.mutateAsync({ id: template.id, data: payload });
+    } else {
+      await createMutation.mutateAsync(payload);
+    }
+    onClose();
+  };
+
+  const isPending = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {/* Name */}
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nazwa szablonu *</FormLabel>
+              <FormControl>
+                <Input placeholder="np. Catering komunijny" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Slug */}
+        <FormField
+          control={form.control}
+          name="slug"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Slug *</FormLabel>
+              <FormControl>
+                <Input placeholder="np. catering-komunijny" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Description */}
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Opis</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Krótki opis szablonu..."
+                  rows={3}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Image URL */}
+        <FormField
+          control={form.control}
+          name="imageUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>URL zdjęcia</FormLabel>
+              <FormControl>
+                <Input placeholder="https://..." {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex items-center gap-6">
+          {/* Display order */}
+          <FormField
+            control={form.control}
+            name="displayOrder"
+            render={({ field }) => (
+              <FormItem className="flex-1">
+                <FormLabel>Kolejność wyświetlania</FormLabel>
+                <FormControl>
+                  <Input type="number" min={0} {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Active */}
+          <FormField
+            control={form.control}
+            name="isActive"
+            render={({ field }) => (
+              <FormItem className="flex items-center gap-2 mt-6">
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </FormControl>
+                <FormLabel className="!mt-0">Aktywny</FormLabel>
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Anuluj
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {isEdit ? 'Zapisz zmiany' : 'Utwórz szablon'}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateList.tsx
+++ b/apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateList.tsx
@@ -1,0 +1,191 @@
+// apps/frontend/src/app/dashboard/catering/templates/components/CateringTemplateList.tsx
+'use client';
+
+import { useState } from 'react';
+import { MoreHorizontal, Pencil, Trash2, Package, BadgeCheck, BadgeX, ChevronDown, ChevronRight } from 'lucide-react';
+import { useDeleteCateringTemplate } from '@/hooks/use-catering';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { CATERING_PRICE_TYPE_LABELS } from '@/types/catering.types';
+import type { CateringTemplate, CateringPackage } from '@/types/catering.types';
+
+interface Props {
+  templates: CateringTemplate[];
+  onEdit: (template: CateringTemplate) => void;
+}
+
+export function CateringTemplateList({ templates, onEdit }: Props) {
+  const [expanded, setExpanded] = useState<string[]>([]);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const deleteMutation = useDeleteCateringTemplate();
+
+  const toggle = (id: string) =>
+    setExpanded((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+
+  const handleDelete = async () => {
+    if (!deleteId) return;
+    await deleteMutation.mutateAsync(deleteId);
+    setDeleteId(null);
+  };
+
+  return (
+    <>
+      <div className="space-y-3">
+        {templates.map((template) => (
+          <div
+            key={template.id}
+            className="rounded-lg border bg-card shadow-sm"
+          >
+            {/* Template header */}
+            <div className="flex items-center justify-between p-4">
+              <button
+                onClick={() => toggle(template.id)}
+                className="flex items-center gap-3 text-left flex-1"
+              >
+                {expanded.includes(template.id) ? (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+                )}
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">{template.name}</span>
+                    {template.isActive ? (
+                      <BadgeCheck className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <BadgeX className="h-4 w-4 text-muted-foreground" />
+                    )}
+                    <span className="text-xs text-muted-foreground font-mono">
+                      /{template.slug}
+                    </span>
+                  </div>
+                  {template.description && (
+                    <p className="text-sm text-muted-foreground mt-0.5">
+                      {template.description}
+                    </p>
+                  )}
+                </div>
+                <div className="ml-auto mr-3 flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    {template.packages?.length ?? 0}{' '}
+                    {template.packages?.length === 1 ? 'pakiet' : 'pakiety/ów'}
+                  </span>
+                </div>
+              </button>
+
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => onEdit(template)}>
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edytuj
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => setDeleteId(template.id)}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Usuń
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+
+            {/* Packages */}
+            {expanded.includes(template.id) && (
+              <div className="border-t px-4 pb-4 pt-3">
+                {template.packages && template.packages.length > 0 ? (
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+                      Pakiety
+                    </p>
+                    {template.packages.map((pkg) => (
+                      <PackageRow key={pkg.id} pkg={pkg} />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+                    <Package className="h-4 w-4" />
+                    Brak pakietów — dodaj pierwszy pakiet w widoku szczegółów
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Confirm delete */}
+      <AlertDialog open={!!deleteId} onOpenChange={() => setDeleteId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Usuń szablon?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Spowoduje to usunięcie szablonu wraz ze wszystkimi pakietami i sekcjami.
+              Tej operacji nie można cofnąć.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Anuluj</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Usuń
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function PackageRow({ pkg }: { pkg: CateringPackage }) {
+  return (
+    <div className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+      <div className="flex items-center gap-2">
+        <span className="font-medium">{pkg.name}</span>
+        {pkg.badgeText && (
+          <Badge variant="secondary" className="text-xs">{pkg.badgeText}</Badge>
+        )}
+        {pkg.isPopular && (
+          <Badge className="text-xs">Popularny</Badge>
+        )}
+        {!pkg.isActive && (
+          <Badge variant="outline" className="text-xs text-muted-foreground">Nieaktywny</Badge>
+        )}
+      </div>
+      <div className="flex items-center gap-3 text-muted-foreground">
+        <span>{CATERING_PRICE_TYPE_LABELS[pkg.priceType]}</span>
+        <span className="font-medium text-foreground">
+          {pkg.basePrice.toFixed(2)} zł
+        </span>
+        <span className="text-xs">
+          {pkg.sections?.length ?? 0} sekcji
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/templates/page.tsx
+++ b/apps/frontend/src/app/dashboard/catering/templates/page.tsx
@@ -1,0 +1,98 @@
+// apps/frontend/src/app/dashboard/catering/templates/page.tsx
+'use client';
+
+import { useState } from 'react';
+import { UtensilsCrossed, Plus, Loader2 } from 'lucide-react';
+import { useCateringTemplates } from '@/hooks/use-catering';
+import { CateringTemplateList } from './components/CateringTemplateList';
+import { CateringTemplateForm } from './components/CateringTemplateForm';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { CateringTemplate } from '@/types/catering.types';
+
+export default function CateringTemplatesPage() {
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingTemplate, setEditingTemplate] = useState<CateringTemplate | null>(null);
+
+  const { data: templates, isLoading } = useCateringTemplates(true);
+
+  const handleCreate = () => {
+    setEditingTemplate(null);
+    setFormOpen(true);
+  };
+
+  const handleEdit = (template: CateringTemplate) => {
+    setEditingTemplate(template);
+    setFormOpen(true);
+  };
+
+  const handleClose = () => {
+    setFormOpen(false);
+    setEditingTemplate(null);
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <UtensilsCrossed className="h-8 w-8" />
+            Szablony cateringu
+          </h1>
+          <p className="text-muted-foreground">
+            Zarządzanie szablonami i pakietami cateringowymi
+          </p>
+        </div>
+        <Button onClick={handleCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          Nowy szablon
+        </Button>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : templates && templates.length > 0 ? (
+        <CateringTemplateList
+          templates={templates}
+          onEdit={handleEdit}
+        />
+      ) : (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16">
+          <UtensilsCrossed className="h-12 w-12 text-muted-foreground/50" />
+          <h3 className="mt-4 text-lg font-medium">Brak szablonów</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Utwórz pierwszy szablon cateringowy
+          </p>
+          <Button onClick={handleCreate} className="mt-4">
+            <Plus className="mr-2 h-4 w-4" />
+            Nowy szablon
+          </Button>
+        </div>
+      )}
+
+      {/* Dialog: Template Form */}
+      <Dialog open={formOpen} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle>
+              {editingTemplate ? 'Edytuj szablon' : 'Nowy szablon cateringu'}
+            </DialogTitle>
+          </DialogHeader>
+          <CateringTemplateForm
+            template={editingTemplate}
+            onClose={handleClose}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/components/DashboardNav.tsx
+++ b/apps/frontend/src/app/dashboard/components/DashboardNav.tsx
@@ -15,6 +15,7 @@ import {
   Menu,
   X,
   Building2,
+  UtensilsCrossed,
 } from 'lucide-react';
 
 // ── Nav item types ─────────────────────────────────────
@@ -31,6 +32,18 @@ const NAV_ITEMS: NavItem[] = [
     label: 'Dashboard',
     href: '/dashboard',
     icon: <LayoutDashboard className="h-4 w-4" />,
+  },
+  {
+    label: 'Catering',
+    href: '/dashboard/catering',
+    icon: <UtensilsCrossed className="h-4 w-4" />,
+    children: [
+      {
+        label: 'Szablony',
+        href: '/dashboard/catering/templates',
+        icon: <UtensilsCrossed className="h-4 w-4" />,
+      },
+    ],
   },
   {
     label: 'Usługi dodatkowe',
@@ -72,7 +85,6 @@ export default function DashboardNav() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState<string[]>(() => {
-    // Auto-expand section if current path matches a child
     const expanded: string[] = [];
     for (const item of NAV_ITEMS) {
       if (item.children?.some((child) => pathname.startsWith(child.href))) {
@@ -95,10 +107,8 @@ export default function DashboardNav() {
     return pathname.startsWith(href);
   };
 
-  // ── Render nav link ─────────────────────────────────
   const renderItem = (item: NavItem, depth = 0) => {
     const hasChildren = item.children && item.children.length > 0;
-    const active = isActive(item.href);
     const isExpanded = expandedSections.includes(item.label);
 
     if (hasChildren) {
@@ -137,7 +147,7 @@ export default function DashboardNav() {
         href={item.href}
         onClick={() => setMobileOpen(false)}
         className={`flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-          active
+          isActive(item.href)
             ? 'bg-primary/10 text-primary'
             : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
         }`}
@@ -148,16 +158,12 @@ export default function DashboardNav() {
     );
   };
 
-  // ── Sidebar content ─────────────────────────────────
   const navContent = (
     <nav className="flex flex-col gap-1 p-4">
-      {/* Logo / brand */}
       <div className="mb-4 px-3">
         <h2 className="text-lg font-bold tracking-tight">Gościniec</h2>
         <p className="text-xs text-muted-foreground">Panel zarządzania</p>
       </div>
-
-      {/* Navigation items */}
       <div className="space-y-1">
         {NAV_ITEMS.map((item) => renderItem(item))}
       </div>
@@ -166,7 +172,6 @@ export default function DashboardNav() {
 
   return (
     <>
-      {/* Mobile toggle */}
       <button
         onClick={() => setMobileOpen(!mobileOpen)}
         className="fixed left-4 top-4 z-50 rounded-md border bg-background p-2 shadow-sm lg:hidden"
@@ -179,7 +184,6 @@ export default function DashboardNav() {
         )}
       </button>
 
-      {/* Mobile overlay */}
       {mobileOpen && (
         <div
           className="fixed inset-0 z-40 bg-black/50 lg:hidden"
@@ -187,7 +191,6 @@ export default function DashboardNav() {
         />
       )}
 
-      {/* Sidebar */}
       <aside
         className={`fixed inset-y-0 left-0 z-40 w-64 border-r bg-background transition-transform duration-200 lg:relative lg:translate-x-0 ${
           mobileOpen ? 'translate-x-0' : '-translate-x-full'

--- a/apps/frontend/src/hooks/use-catering.ts
+++ b/apps/frontend/src/hooks/use-catering.ts
@@ -1,0 +1,318 @@
+// apps/frontend/src/hooks/use-catering.ts
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  UseQueryResult,
+  UseMutationResult,
+} from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  CateringTemplate,
+  CateringPackage,
+  CateringPackageSection,
+  CateringSectionOption,
+  CreateCateringTemplateInput,
+  UpdateCateringTemplateInput,
+  CreateCateringPackageInput,
+  UpdateCateringPackageInput,
+  CreateCateringSectionInput,
+  UpdateCateringSectionInput,
+  CreateSectionOptionInput,
+  UpdateSectionOptionInput,
+} from '@/types/catering.types';
+
+const QUERY_KEYS = {
+  templates: ['catering-templates'] as const,
+  template: (id: string) => ['catering-templates', id] as const,
+  package: (id: string) => ['catering-packages', id] as const,
+};
+
+// ═══════════════════════════════════════════════════════════════
+// TEMPLATES — Queries
+// ═══════════════════════════════════════════════════════════════
+
+export function useCateringTemplates(
+  includeInactive = false
+): UseQueryResult<CateringTemplate[]> {
+  return useQuery({
+    queryKey: [...QUERY_KEYS.templates, { includeInactive }],
+    queryFn: async () => {
+      const params = includeInactive ? '?includeInactive=true' : '';
+      const res = await api.get(`/catering/templates${params}`);
+      return res.data.data;
+    },
+    staleTime: 5_000,
+  });
+}
+
+export function useCateringTemplate(
+  id: string
+): UseQueryResult<CateringTemplate> {
+  return useQuery({
+    queryKey: QUERY_KEYS.template(id),
+    queryFn: async () => {
+      const res = await api.get(`/catering/templates/${id}`);
+      return res.data.data;
+    },
+    enabled: !!id,
+    staleTime: 5_000,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// TEMPLATES — Mutations
+// ═══════════════════════════════════════════════════════════════
+
+export function useCreateCateringTemplate(): UseMutationResult<
+  CateringTemplate,
+  Error,
+  CreateCateringTemplateInput
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      const res = await api.post('/catering/templates', data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.templates,
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useUpdateCateringTemplate(): UseMutationResult<
+  CateringTemplate,
+  Error,
+  { id: string; data: UpdateCateringTemplateInput }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, data }) => {
+      const res = await api.patch(`/catering/templates/${id}`, data);
+      return res.data.data;
+    },
+    onSuccess: async (_data, { id }) => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.templates,
+        refetchType: 'all',
+      });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.template(id) });
+    },
+  });
+}
+
+export function useDeleteCateringTemplate(): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id) => {
+      await api.delete(`/catering/templates/${id}`);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.templates,
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// PACKAGES — Mutations
+// ═══════════════════════════════════════════════════════════════
+
+export function useCreateCateringPackage(
+  templateId: string
+): UseMutationResult<CateringPackage, Error, CreateCateringPackageInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      const res = await api.post(`/catering/templates/${templateId}/packages`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.templates,
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useUpdateCateringPackage(
+  templateId: string
+): UseMutationResult<
+  CateringPackage,
+  Error,
+  { packageId: string; data: UpdateCateringPackageInput }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ packageId, data }) => {
+      const res = await api.patch(
+        `/catering/templates/${templateId}/packages/${packageId}`,
+        data
+      );
+      return res.data.data;
+    },
+    onSuccess: async (_data, { packageId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEYS.package(packageId) });
+    },
+  });
+}
+
+export function useDeleteCateringPackage(
+  templateId: string
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (packageId) => {
+      await api.delete(`/catering/templates/${templateId}/packages/${packageId}`);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.templates,
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTIONS — Mutations
+// ═══════════════════════════════════════════════════════════════
+
+export function useCreateCateringSection(
+  packageId: string,
+  templateId: string
+): UseMutationResult<CateringPackageSection, Error, CreateCateringSectionInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      const res = await api.post(`/catering/packages/${packageId}/sections`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useUpdateCateringSection(
+  templateId: string
+): UseMutationResult<
+  CateringPackageSection,
+  Error,
+  { sectionId: string; data: UpdateCateringSectionInput }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ sectionId, data }) => {
+      const res = await api.patch(`/catering/sections/${sectionId}`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useDeleteCateringSection(
+  templateId: string
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (sectionId) => {
+      await api.delete(`/catering/sections/${sectionId}`);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// SECTION OPTIONS — Mutations
+// ═══════════════════════════════════════════════════════════════
+
+export function useAddSectionOption(
+  sectionId: string,
+  templateId: string
+): UseMutationResult<CateringSectionOption, Error, CreateSectionOptionInput> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data) => {
+      const res = await api.post(`/catering/sections/${sectionId}/options`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useUpdateSectionOption(
+  templateId: string
+): UseMutationResult<
+  CateringSectionOption,
+  Error,
+  { optionId: string; data: UpdateSectionOptionInput }
+> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ optionId, data }) => {
+      const res = await api.patch(`/catering/options/${optionId}`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}
+
+export function useRemoveSectionOption(
+  templateId: string
+): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (optionId) => {
+      await api.delete(`/catering/options/${optionId}`);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: QUERY_KEYS.template(templateId),
+        refetchType: 'all',
+      });
+    },
+  });
+}

--- a/apps/frontend/src/types/catering.types.ts
+++ b/apps/frontend/src/types/catering.types.ts
@@ -1,0 +1,214 @@
+// apps/frontend/src/types/catering.types.ts
+
+// ═══════════════════════════════════════════════════════════════
+// Enums
+// ═══════════════════════════════════════════════════════════════
+
+export type CateringPriceType = 'PER_PERSON' | 'FLAT' | 'TIERED';
+
+export const CATERING_PRICE_TYPE_LABELS: Record<CateringPriceType, string> = {
+  PER_PERSON: 'Za osobę',
+  FLAT: 'Kwota stała',
+  TIERED: 'Progi cenowe',
+};
+
+// ═══════════════════════════════════════════════════════════════
+// Catering Template
+// ═══════════════════════════════════════════════════════════════
+
+export interface CateringTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  slug: string;
+  imageUrl: string | null;
+  isActive: boolean;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  packages?: CateringPackage[];
+}
+
+export interface CreateCateringTemplateInput {
+  name: string;
+  slug: string;
+  description?: string;
+  imageUrl?: string;
+  isActive?: boolean;
+  displayOrder?: number;
+}
+
+export interface UpdateCateringTemplateInput {
+  name?: string;
+  slug?: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  isActive?: boolean;
+  displayOrder?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Catering Package
+// ═══════════════════════════════════════════════════════════════
+
+export interface CateringPackage {
+  id: string;
+  templateId: string;
+  name: string;
+  description: string | null;
+  shortDescription: string | null;
+  priceType: CateringPriceType;
+  basePrice: number;
+  tieredPricing: Record<string, unknown> | null;
+  badgeText: string | null;
+  isPopular: boolean;
+  displayOrder: number;
+  isActive: boolean;
+  minGuests: number | null;
+  maxGuests: number | null;
+  createdAt: string;
+  updatedAt: string;
+  template?: CateringTemplate;
+  sections?: CateringPackageSection[];
+}
+
+export interface CreateCateringPackageInput {
+  name: string;
+  basePrice: number;
+  description?: string;
+  shortDescription?: string;
+  priceType?: CateringPriceType;
+  tieredPricing?: Record<string, unknown>;
+  badgeText?: string;
+  isPopular?: boolean;
+  displayOrder?: number;
+  isActive?: boolean;
+  minGuests?: number;
+  maxGuests?: number;
+}
+
+export interface UpdateCateringPackageInput {
+  name?: string;
+  description?: string | null;
+  shortDescription?: string | null;
+  priceType?: CateringPriceType;
+  basePrice?: number;
+  tieredPricing?: Record<string, unknown> | null;
+  badgeText?: string | null;
+  isPopular?: boolean;
+  displayOrder?: number;
+  isActive?: boolean;
+  minGuests?: number | null;
+  maxGuests?: number | null;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Catering Package Section
+// ═══════════════════════════════════════════════════════════════
+
+export interface DishCategory {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  displayOrder: number;
+  isActive: boolean;
+}
+
+export interface Dish {
+  id: string;
+  name: string;
+  description: string | null;
+  price: number | null;
+  isActive: boolean;
+}
+
+export interface CateringSectionOption {
+  id: string;
+  sectionId: string;
+  dishId: string;
+  customPrice: number | null;
+  isDefault: boolean;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  dish?: Dish;
+}
+
+export interface CateringPackageSection {
+  id: string;
+  packageId: string;
+  categoryId: string;
+  name: string | null;
+  description: string | null;
+  minSelect: number;
+  maxSelect: number | null;
+  isRequired: boolean;
+  displayOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  category?: DishCategory;
+  options?: CateringSectionOption[];
+}
+
+export interface CreateCateringSectionInput {
+  categoryId: string;
+  name?: string;
+  description?: string;
+  minSelect?: number;
+  maxSelect?: number;
+  isRequired?: boolean;
+  displayOrder?: number;
+}
+
+export interface UpdateCateringSectionInput {
+  name?: string | null;
+  description?: string | null;
+  minSelect?: number;
+  maxSelect?: number;
+  isRequired?: boolean;
+  displayOrder?: number;
+}
+
+export interface CreateSectionOptionInput {
+  dishId: string;
+  customPrice?: number | null;
+  isDefault?: boolean;
+  displayOrder?: number;
+}
+
+export interface UpdateSectionOptionInput {
+  customPrice?: number | null;
+  isDefault?: boolean;
+  displayOrder?: number;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// API Response wrappers
+// ═══════════════════════════════════════════════════════════════
+
+export interface CateringTemplatesResponse {
+  success: boolean;
+  data: CateringTemplate[];
+  count: number;
+}
+
+export interface CateringTemplateResponse {
+  success: boolean;
+  data: CateringTemplate;
+}
+
+export interface CateringPackageResponse {
+  success: boolean;
+  data: CateringPackage;
+}
+
+export interface CateringSectionResponse {
+  success: boolean;
+  data: CateringPackageSection;
+}
+
+export interface CateringSectionOptionResponse {
+  success: boolean;
+  data: CateringSectionOption;
+}


### PR DESCRIPTION
## Co zawiera

- `src/types/catering.types.ts` — typy TS 1:1 z backend DTOs
- `src/hooks/use-catering.ts` — React Query hooks (templates, packages, sections, options)
- `src/app/dashboard/catering/templates/page.tsx` — strona listy szablonów
- `…/components/CateringTemplateList.tsx` — lista z accordion i pakietami
- `…/components/CateringTemplateForm.tsx` — formularz create/edit z Zod + auto-slug
- `src/app/dashboard/components/DashboardNav.tsx` — +Catering z submenu Szablony

## Weryfikacja
- ✅ `tsc --noEmit` — 0 błędów
- ✅ Strona dostępna pod `/dashboard/catering/templates`