### PR TITLE
feat(frontend): Catering Phase 2 — zamówienia (lista, wizard, szczegóły)

### DIFF
--- a/apps/frontend/src/app/dashboard/catering/orders/[id]/page.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/[id]/page.tsx
@@ -1,0 +1,350 @@
+// apps/frontend/src/app/dashboard/catering/orders/[id]/page.tsx
+'use client';
+
+import { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  ArrowLeft,
+  Edit,
+  Loader2,
+  MoreVertical,
+  Trash2,
+} from 'lucide-react';
+import { useCateringOrder, useDeleteCateringOrder } from '@/hooks/use-catering-orders';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { OrderStatusBadge } from '../components/OrderStatusBadge';
+import { OrderTimeline } from '../components/OrderTimeline';
+import { ChangeStatusDialog } from '../components/ChangeStatusDialog';
+import { DELIVERY_TYPE_LABEL } from '@/types/catering-order.types';
+
+function formatPrice(value: number | string) {
+  return new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN' }).format(Number(value));
+}
+
+export default function CateringOrderDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false);
+
+  const { data: order, isLoading } = useCateringOrder(id);
+  const deleteMutation = useDeleteCateringOrder();
+
+  const handleDelete = async () => {
+    if (!confirm('Czy na pewno usunąć to zamówienie?')) return;
+    await deleteMutation.mutateAsync(id);
+    router.push('/dashboard/catering/orders');
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!order) {
+    return (
+      <div className="p-6">
+        <p className="text-muted-foreground">Zamówienie nie istnieje</p>
+      </div>
+    );
+  }
+
+  const clientName =
+    order.client.clientType === 'COMPANY' && order.client.companyName
+      ? order.client.companyName
+      : `${order.client.firstName} ${order.client.lastName}`;
+
+  const canDelete = order.status === 'DRAFT' || order.status === 'CANCELLED';
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={() => router.push('/dashboard/catering/orders')}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-bold font-mono">{order.orderNumber}</h1>
+              <OrderStatusBadge status={order.status} />
+            </div>
+            <p className="text-muted-foreground text-sm mt-0.5">{clientName}</p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => setStatusDialogOpen(true)}
+          >
+            Zmień status
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => router.push(`/dashboard/catering/orders/${id}/edit`)}
+          >
+            <Edit className="mr-2 h-4 w-4" /> Edytuj
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon">
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={!canDelete}
+                className="text-destructive focus:text-destructive"
+                onClick={handleDelete}
+              >
+                <Trash2 className="mr-2 h-4 w-4" /> Usuń zamówienie
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Lewa kolumna — dane zamówienia */}
+        <div className="lg:col-span-2 space-y-6">
+
+          {/* Wydarzenie */}
+          <Card>
+            <CardHeader><CardTitle className="text-base">Wydarzenie</CardTitle></CardHeader>
+            <CardContent className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-muted-foreground">Nazwa</p>
+                <p className="font-medium">{order.eventName ?? '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Data i godzina</p>
+                <p className="font-medium">
+                  {order.eventDate ?? '—'} {order.eventTime ? `· ${order.eventTime}` : ''}
+                </p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Miejsce</p>
+                <p className="font-medium">{order.eventLocation ?? '—'}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Goście</p>
+                <p className="font-medium">{order.guestsCount}</p>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Dostawa */}
+          <Card>
+            <CardHeader><CardTitle className="text-base">Dostawa</CardTitle></CardHeader>
+            <CardContent className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-muted-foreground">Typ</p>
+                <p className="font-medium">{DELIVERY_TYPE_LABEL[order.deliveryType]}</p>
+              </div>
+              {order.deliveryType === 'DELIVERY' && (
+                <>
+                  <div>
+                    <p className="text-muted-foreground">Adres dostawy</p>
+                    <p className="font-medium">{order.deliveryAddress ?? '—'}</p>
+                  </div>
+                  <div>
+                    <p className="text-muted-foreground">Data dostawy</p>
+                    <p className="font-medium">{order.deliveryDate ?? '—'} {order.deliveryTime ? `· ${order.deliveryTime}` : ''}</p>
+                  </div>
+                </>
+              )}
+              {order.deliveryNotes && (
+                <div className="col-span-2">
+                  <p className="text-muted-foreground">Uwagi do dostawy</p>
+                  <p className="font-medium">{order.deliveryNotes}</p>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Dania */}
+          {order.items.length > 0 && (
+            <Card>
+              <CardHeader><CardTitle className="text-base">Dania</CardTitle></CardHeader>
+              <CardContent>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left pb-2 font-medium text-muted-foreground">Danie</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Ilość</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Cena</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Razem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {order.items.map(item => (
+                      <tr key={item.id} className="border-b last:border-0">
+                        <td className="py-2">
+                          {item.dishNameSnapshot}
+                          {item.note && <span className="block text-xs text-muted-foreground">{item.note}</span>}
+                        </td>
+                        <td className="text-right py-2">{item.quantity}</td>
+                        <td className="text-right py-2">{formatPrice(item.unitPrice)}</td>
+                        <td className="text-right py-2 font-medium">{formatPrice(item.totalPrice)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Extras */}
+          {order.extras.length > 0 && (
+            <Card>
+              <CardHeader><CardTitle className="text-base">Usługi dodatkowe</CardTitle></CardHeader>
+              <CardContent>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left pb-2 font-medium text-muted-foreground">Usługa</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Ilość</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Cena</th>
+                      <th className="text-right pb-2 font-medium text-muted-foreground">Razem</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {order.extras.map(extra => (
+                      <tr key={extra.id} className="border-b last:border-0">
+                        <td className="py-2">
+                          {extra.name}
+                          {extra.description && <span className="block text-xs text-muted-foreground">{extra.description}</span>}
+                        </td>
+                        <td className="text-right py-2">{extra.quantity}</td>
+                        <td className="text-right py-2">{formatPrice(extra.unitPrice)}</td>
+                        <td className="text-right py-2 font-medium">{formatPrice(extra.totalPrice)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Prawa kolumna — podsumowanie + historia */}
+        <div className="space-y-6">
+
+          {/* Klient i kontakt */}
+          <Card>
+            <CardHeader><CardTitle className="text-base">Klient</CardTitle></CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <p className="font-medium">{clientName}</p>
+              {order.client.email && <p className="text-muted-foreground">{order.client.email}</p>}
+              {order.client.phone && <p className="text-muted-foreground">{order.client.phone}</p>}
+              {(order.contactName || order.contactPhone || order.contactEmail) && (
+                <div className="pt-2 border-t">
+                  <p className="text-xs font-medium text-muted-foreground mb-1">Kontakt do zamówienia</p>
+                  {order.contactName && <p>{order.contactName}</p>}
+                  {order.contactPhone && <p className="text-muted-foreground">{order.contactPhone}</p>}
+                  {order.contactEmail && <p className="text-muted-foreground">{order.contactEmail}</p>}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Cennik */}
+          <Card>
+            <CardHeader><CardTitle className="text-base">Podsumowanie finansowe</CardTitle></CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Dania</span>
+                <span>{formatPrice(order.subtotal)}</span>
+              </div>
+              {order.extrasTotalPrice > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Usługi dodatkowe</span>
+                  <span>{formatPrice(order.extrasTotalPrice)}</span>
+                </div>
+              )}
+              {order.discountAmount && Number(order.discountAmount) > 0 && (
+                <div className="flex justify-between text-green-600">
+                  <span>Rabat
+                    {order.discountType === 'PERCENTAGE' && order.discountValue
+                      ? ` (${order.discountValue}%)`
+                      : ''}
+                  </span>
+                  <span>-{formatPrice(order.discountAmount)}</span>
+                </div>
+              )}
+              <div className="flex justify-between font-bold border-t pt-2">
+                <span>Razem</span>
+                <span>{formatPrice(order.totalPrice)}</span>
+              </div>
+
+              {/* Depozyty */}
+              {order.deposits.length > 0 && (
+                <div className="pt-2 border-t space-y-1">
+                  <p className="text-xs font-medium text-muted-foreground">Depozyty</p>
+                  {order.deposits.map(d => (
+                    <div key={d.id} className="flex justify-between text-xs">
+                      <span className={d.paid ? 'text-green-600' : 'text-muted-foreground'}>
+                        {d.title ?? 'Depozyt'} · {d.dueDate}
+                      </span>
+                      <span className={d.paid ? 'text-green-600 font-medium' : ''}>
+                        {d.paid ? '✓ ' : ''}{formatPrice(d.amount)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Uwagi */}
+          {(order.notes || order.specialRequirements) && (
+            <Card>
+              <CardHeader><CardTitle className="text-base">Uwagi</CardTitle></CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {order.notes && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">Uwagi</p>
+                    <p>{order.notes}</p>
+                  </div>
+                )}
+                {order.specialRequirements && (
+                  <div className="pt-2 border-t">
+                    <p className="text-xs text-muted-foreground mb-1">Specjalne wymagania</p>
+                    <p>{order.specialRequirements}</p>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Timeline */}
+          <Card>
+            <CardContent className="pt-6">
+              <OrderTimeline orderId={id} />
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Dialog zmiany statusu */}
+      <ChangeStatusDialog
+        orderId={id}
+        currentStatus={order.status}
+        open={statusDialogOpen}
+        onClose={() => setStatusDialogOpen(false)}
+      />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/ChangeStatusDialog.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/ChangeStatusDialog.tsx
@@ -1,0 +1,93 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/ChangeStatusDialog.tsx
+'use client';
+
+import { useState } from 'react';
+import { useChangeCateringOrderStatus } from '@/hooks/use-catering-orders';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import type { CateringOrderStatus } from '@/types/catering-order.types';
+import { ORDER_STATUS_LABEL } from '@/types/catering-order.types';
+
+const STATUSES = Object.keys(ORDER_STATUS_LABEL) as CateringOrderStatus[];
+
+interface Props {
+  orderId: string;
+  currentStatus: CateringOrderStatus;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ChangeStatusDialog({ orderId, currentStatus, open, onClose }: Props) {
+  const [status, setStatus] = useState<CateringOrderStatus>(currentStatus);
+  const [reason, setReason] = useState('');
+  const mutation = useChangeCateringOrderStatus(orderId);
+
+  const handleSubmit = async () => {
+    await mutation.mutateAsync({ status, reason: reason.trim() || null });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Zmień status zamówienia</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Nowy status</label>
+            <Select value={status} onValueChange={v => setStatus(v as CateringOrderStatus)}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUSES.map(s => (
+                  <SelectItem key={s} value={s}>{ORDER_STATUS_LABEL[s]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <label className="text-sm font-medium">Powód zmiany (opcjonalnie)</label>
+            <Textarea
+              placeholder="Wpisz powód..."
+              value={reason}
+              onChange={e => setReason(e.target.value)}
+              rows={3}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={mutation.isPending}>
+            Anuluj
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={mutation.isPending || status === currentStatus}
+          >
+            {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Zapisz
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/NewOrderWizard.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/NewOrderWizard.tsx
@@ -1,0 +1,581 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/NewOrderWizard.tsx
+'use client';
+
+import { useState } from 'react';
+import { useCreateCateringOrder } from '@/hooks/use-catering-orders';
+import { useCateringTemplates } from '@/hooks/use-catering';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent } from '@/components/ui/card';
+import { Loader2, ChevronRight, ChevronLeft, Check, Plus, Trash2 } from 'lucide-react';
+import type {
+  CateringDeliveryType,
+  CreateOrderItemInput,
+  CreateOrderExtraInput,
+} from '@/types/catering-order.types';
+import { DELIVERY_TYPE_LABEL } from '@/types/catering-order.types';
+
+// ─── Typy stanu formularza ─────────────────────────────────────
+
+interface WizardState {
+  // Krok 1 — klient
+  clientId: string;
+  clientName: string; // tylko do wyświetlenia
+  // Krok 2 — wydarzenie
+  eventName: string;
+  eventDate: string;
+  eventTime: string;
+  eventLocation: string;
+  guestsCount: string;
+  // Krok 3 — szablon / pakiet
+  templateId: string;
+  packageId: string;
+  // Krok 4 — dania (uproszczony ręczny wpis)
+  items: CreateOrderItemInput[];
+  extras: CreateOrderExtraInput[];
+  // Krok 5 — logistyka
+  deliveryType: CateringDeliveryType;
+  deliveryAddress: string;
+  deliveryDate: string;
+  deliveryTime: string;
+  deliveryNotes: string;
+  // Krok 6 — kontakt + uwagi
+  contactName: string;
+  contactPhone: string;
+  contactEmail: string;
+  notes: string;
+  specialRequirements: string;
+}
+
+const INITIAL: WizardState = {
+  clientId: '',
+  clientName: '',
+  eventName: '',
+  eventDate: '',
+  eventTime: '',
+  eventLocation: '',
+  guestsCount: '0',
+  templateId: '',
+  packageId: '',
+  items: [],
+  extras: [],
+  deliveryType: 'ON_SITE',
+  deliveryAddress: '',
+  deliveryDate: '',
+  deliveryTime: '',
+  deliveryNotes: '',
+  contactName: '',
+  contactPhone: '',
+  contactEmail: '',
+  notes: '',
+  specialRequirements: '',
+};
+
+const STEPS = [
+  'Klient',
+  'Wydarzenie',
+  'Szablon / Pakiet',
+  'Dania i Extras',
+  'Logistyka',
+  'Podsumowanie',
+];
+
+// ─── Komponent główny ─────────────────────────────────────────
+
+interface Props {
+  onSuccess: (id: string) => void;
+}
+
+export function NewOrderWizard({ onSuccess }: Props) {
+  const [step, setStep] = useState(0);
+  const [state, setState] = useState<WizardState>(INITIAL);
+  const [clientSearch, setClientSearch] = useState('');
+  const [clients, setClients] = useState<{ id: string; label: string }[]>([]);
+  const [clientSearching, setClientSearching] = useState(false);
+
+  const { data: templates } = useCateringTemplates(false);
+  const createOrder = useCreateCateringOrder();
+
+  const set = (partial: Partial<WizardState>) =>
+    setState(prev => ({ ...prev, ...partial }));
+
+  // Wyszukiwanie klientów przez API
+  const searchClients = async () => {
+    if (!clientSearch.trim()) return;
+    setClientSearching(true);
+    try {
+      const { api } = await import('@/lib/api');
+      const res = await api.get(`/clients?search=${encodeURIComponent(clientSearch)}&limit=10`);
+      const data = res.data.data ?? [];
+      setClients(
+        data.map((c: {
+          id: string;
+          firstName: string;
+          lastName: string;
+          companyName?: string;
+          clientType: string;
+        }) => ({
+          id: c.id,
+          label:
+            c.clientType === 'COMPANY' && c.companyName
+              ? c.companyName
+              : `${c.firstName} ${c.lastName}`,
+        }))
+      );
+    } finally {
+      setClientSearching(false);
+    }
+  };
+
+  // Wybrany szablon → dostępne pakiety
+  const selectedTemplate = templates?.find(t => t.id === state.templateId);
+
+  // ─── Submit ───────────────────────────────────────────────────
+  const handleSubmit = async () => {
+    const order = await createOrder.mutateAsync({
+      clientId: state.clientId,
+      templateId: state.templateId || null,
+      packageId: state.packageId || null,
+      deliveryType: state.deliveryType,
+      eventName: state.eventName || null,
+      eventDate: state.eventDate || null,
+      eventTime: state.eventTime || null,
+      eventLocation: state.eventLocation || null,
+      guestsCount: parseInt(state.guestsCount, 10) || 0,
+      deliveryAddress: state.deliveryAddress || null,
+      deliveryDate: state.deliveryDate || null,
+      deliveryTime: state.deliveryTime || null,
+      deliveryNotes: state.deliveryNotes || null,
+      contactName: state.contactName || null,
+      contactPhone: state.contactPhone || null,
+      contactEmail: state.contactEmail || null,
+      notes: state.notes || null,
+      specialRequirements: state.specialRequirements || null,
+      items: state.items.length > 0 ? state.items : undefined,
+      extras: state.extras.length > 0 ? state.extras : undefined,
+    });
+    onSuccess(order.id);
+  };
+
+  // ─── Render ───────────────────────────────────────────────────
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Stepper */}
+      <div className="flex items-center gap-1">
+        {STEPS.map((label, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <div
+              className={`flex items-center justify-center h-7 w-7 rounded-full text-xs font-bold transition-colors ${
+                i < step
+                  ? 'bg-primary text-primary-foreground'
+                  : i === step
+                  ? 'bg-primary text-primary-foreground ring-2 ring-primary/30'
+                  : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {i < step ? <Check className="h-3.5 w-3.5" /> : i + 1}
+            </div>
+            {i < STEPS.length - 1 && (
+              <div className={`h-0.5 w-8 ${
+                i < step ? 'bg-primary' : 'bg-muted'
+              }`} />
+            )}
+          </div>
+        ))}
+        <span className="ml-3 text-sm font-medium">{STEPS[step]}</span>
+      </div>
+
+      {/* Kroki */}
+      <Card>
+        <CardContent className="pt-6">
+          {/* KROK 0 — Klient */}
+          {step === 0 && (
+            <div className="space-y-4">
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Szukaj klienta (imię, nazwisko, firma)..."
+                  value={clientSearch}
+                  onChange={e => setClientSearch(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && searchClients()}
+                />
+                <Button variant="outline" onClick={searchClients} disabled={clientSearching}>
+                  {clientSearching ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Szukaj'}
+                </Button>
+              </div>
+              {clients.length > 0 && (
+                <div className="border rounded-md divide-y">
+                  {clients.map(c => (
+                    <button
+                      key={c.id}
+                      className={`w-full text-left px-4 py-2.5 text-sm hover:bg-muted transition-colors ${
+                        state.clientId === c.id ? 'bg-primary/10 font-medium' : ''
+                      }`}
+                      onClick={() => set({ clientId: c.id, clientName: c.label })}
+                    >
+                      {c.label}
+                      {state.clientId === c.id && (
+                        <Check className="inline ml-2 h-3.5 w-3.5 text-primary" />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {state.clientName && (
+                <p className="text-sm text-green-600 font-medium">Wybrany: {state.clientName}</p>
+              )}
+            </div>
+          )}
+
+          {/* KROK 1 — Wydarzenie */}
+          {step === 1 && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="col-span-2 space-y-1.5">
+                <Label>Nazwa wydarzenia</Label>
+                <Input value={state.eventName} onChange={e => set({ eventName: e.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Data</Label>
+                <Input type="date" value={state.eventDate} onChange={e => set({ eventDate: e.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Godzina</Label>
+                <Input type="time" value={state.eventTime} onChange={e => set({ eventTime: e.target.value })} />
+              </div>
+              <div className="col-span-2 space-y-1.5">
+                <Label>Miejsce</Label>
+                <Input value={state.eventLocation} onChange={e => set({ eventLocation: e.target.value })} />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Liczba gości</Label>
+                <Input type="number" min={0} value={state.guestsCount} onChange={e => set({ guestsCount: e.target.value })} />
+              </div>
+            </div>
+          )}
+
+          {/* KROK 2 — Szablon / Pakiet */}
+          {step === 2 && (
+            <div className="space-y-4">
+              <div className="space-y-1.5">
+                <Label>Szablon cateringu (opcjonalnie)</Label>
+                <Select
+                  value={state.templateId || 'NONE'}
+                  onValueChange={v => set({ templateId: v === 'NONE' ? '' : v, packageId: '' })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Wybierz szablon" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="NONE">— Bez szablonu —</SelectItem>
+                    {templates?.map(t => (
+                      <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {selectedTemplate && selectedTemplate.packages?.length > 0 && (
+                <div className="space-y-1.5">
+                  <Label>Pakiet (opcjonalnie)</Label>
+                  <Select
+                    value={state.packageId || 'NONE'}
+                    onValueChange={v => set({ packageId: v === 'NONE' ? '' : v })}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Wybierz pakiet" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="NONE">— Bez pakietu —</SelectItem>
+                      {selectedTemplate.packages.map((p: { id: string; name: string; basePrice: number }) => (
+                        <SelectItem key={p.id} value={p.id}>
+                          {p.name} — {new Intl.NumberFormat('pl-PL', { style: 'currency', currency: 'PLN' }).format(p.basePrice)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* KROK 3 — Dania i Extras */}
+          {step === 3 && (
+            <div className="space-y-6">
+              {/* Dania — ręczny wpis */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-base">Dania</Label>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      set({ items: [...state.items, { dishId: '', quantity: 1, unitPrice: 0 }] })
+                    }
+                  >
+                    <Plus className="mr-1 h-3 w-3" /> Dodaj danie
+                  </Button>
+                </div>
+                {state.items.map((item, i) => (
+                  <div key={i} className="flex gap-2 items-start">
+                    <Input
+                      placeholder="UUID dania"
+                      value={item.dishId}
+                      onChange={e => {
+                        const items = [...state.items];
+                        items[i] = { ...items[i], dishId: e.target.value };
+                        set({ items });
+                      }}
+                      className="flex-1"
+                    />
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="Ilość"
+                      value={item.quantity}
+                      onChange={e => {
+                        const items = [...state.items];
+                        items[i] = { ...items[i], quantity: parseInt(e.target.value, 10) || 1 };
+                        set({ items });
+                      }}
+                      className="w-20"
+                    />
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="Cena"
+                      value={item.unitPrice}
+                      onChange={e => {
+                        const items = [...state.items];
+                        items[i] = { ...items[i], unitPrice: parseFloat(e.target.value) || 0 };
+                        set({ items });
+                      }}
+                      className="w-28"
+                    />
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => set({ items: state.items.filter((_, j) => j !== i) })}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                ))}
+                {state.items.length === 0 && (
+                  <p className="text-sm text-muted-foreground">Brak dań — możesz dodać je później</p>
+                )}
+              </div>
+
+              {/* Extras */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <Label className="text-base">Usługi dodatkowe</Label>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() =>
+                      set({ extras: [...state.extras, { name: '', quantity: 1, unitPrice: 0 }] })
+                    }
+                  >
+                    <Plus className="mr-1 h-3 w-3" /> Dodaj
+                  </Button>
+                </div>
+                {state.extras.map((extra, i) => (
+                  <div key={i} className="flex gap-2 items-start">
+                    <Input
+                      placeholder="Nazwa usługi"
+                      value={extra.name}
+                      onChange={e => {
+                        const extras = [...state.extras];
+                        extras[i] = { ...extras[i], name: e.target.value };
+                        set({ extras });
+                      }}
+                      className="flex-1"
+                    />
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="Ilość"
+                      value={extra.quantity}
+                      onChange={e => {
+                        const extras = [...state.extras];
+                        extras[i] = { ...extras[i], quantity: parseInt(e.target.value, 10) || 1 };
+                        set({ extras });
+                      }}
+                      className="w-20"
+                    />
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="Cena"
+                      value={extra.unitPrice}
+                      onChange={e => {
+                        const extras = [...state.extras];
+                        extras[i] = { ...extras[i], unitPrice: parseFloat(e.target.value) || 0 };
+                        set({ extras });
+                      }}
+                      className="w-28"
+                    />
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => set({ extras: state.extras.filter((_, j) => j !== i) })}
+                    >
+                      <Trash2 className="h-4 w-4 text-destructive" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* KROK 4 — Logistyka */}
+          {step === 4 && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="col-span-2 space-y-1.5">
+                <Label>Typ dostawy</Label>
+                <Select
+                  value={state.deliveryType}
+                  onValueChange={v => set({ deliveryType: v as CateringDeliveryType })}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(Object.entries(DELIVERY_TYPE_LABEL) as [CateringDeliveryType, string][]).map(([v, l]) => (
+                      <SelectItem key={v} value={v}>{l}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {state.deliveryType === 'DELIVERY' && (
+                <>
+                  <div className="col-span-2 space-y-1.5">
+                    <Label>Adres dostawy</Label>
+                    <Textarea
+                      value={state.deliveryAddress}
+                      onChange={e => set({ deliveryAddress: e.target.value })}
+                      rows={2}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label>Data dostawy</Label>
+                    <Input type="date" value={state.deliveryDate} onChange={e => set({ deliveryDate: e.target.value })} />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label>Godzina dostawy</Label>
+                    <Input type="time" value={state.deliveryTime} onChange={e => set({ deliveryTime: e.target.value })} />
+                  </div>
+                </>
+              )}
+              <div className="col-span-2 space-y-1.5">
+                <Label>Uwagi do logistyki</Label>
+                <Textarea
+                  value={state.deliveryNotes}
+                  onChange={e => set({ deliveryNotes: e.target.value })}
+                  rows={2}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* KROK 5 — Podsumowanie */}
+          {step === 5 && (
+            <div className="space-y-4 text-sm">
+              <div className="grid grid-cols-2 gap-4">
+                <div className="col-span-2 space-y-1.5">
+                  <Label>Osoba kontaktowa</Label>
+                  <Input
+                    placeholder="Imię i nazwisko"
+                    value={state.contactName}
+                    onChange={e => set({ contactName: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>Telefon kontaktowy</Label>
+                  <Input
+                    placeholder="+48..."
+                    value={state.contactPhone}
+                    onChange={e => set({ contactPhone: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label>E-mail kontaktowy</Label>
+                  <Input
+                    type="email"
+                    value={state.contactEmail}
+                    onChange={e => set({ contactEmail: e.target.value })}
+                  />
+                </div>
+                <div className="col-span-2 space-y-1.5">
+                  <Label>Uwagi</Label>
+                  <Textarea
+                    rows={3}
+                    value={state.notes}
+                    onChange={e => set({ notes: e.target.value })}
+                  />
+                </div>
+                <div className="col-span-2 space-y-1.5">
+                  <Label>Specjalne wymagania</Label>
+                  <Textarea
+                    rows={2}
+                    value={state.specialRequirements}
+                    onChange={e => set({ specialRequirements: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              {/* Podsumowanie stanu */}
+              <div className="border rounded-md p-4 space-y-2 bg-muted/30">
+                <p className="font-semibold">Podsumowanie</p>
+                <p><span className="text-muted-foreground">Klient:</span> {state.clientName || '—'}</p>
+                <p><span className="text-muted-foreground">Wydarzenie:</span> {state.eventName || '—'} {state.eventDate && `(${state.eventDate})`}</p>
+                <p><span className="text-muted-foreground">Goście:</span> {state.guestsCount}</p>
+                <p><span className="text-muted-foreground">Typ dostawy:</span> {DELIVERY_TYPE_LABEL[state.deliveryType]}</p>
+                <p><span className="text-muted-foreground">Dania:</span> {state.items.length} pozycji</p>
+                <p><span className="text-muted-foreground">Extras:</span> {state.extras.length} pozycji</p>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Nawigacja kroków */}
+      <div className="flex justify-between">
+        <Button
+          variant="outline"
+          onClick={() => setStep(s => s - 1)}
+          disabled={step === 0}
+        >
+          <ChevronLeft className="mr-1 h-4 w-4" /> Wstecz
+        </Button>
+
+        {step < STEPS.length - 1 ? (
+          <Button
+            onClick={() => setStep(s => s + 1)}
+            disabled={step === 0 && !state.clientId}
+          >
+            Dalej <ChevronRight className="ml-1 h-4 w-4" />
+          </Button>
+        ) : (
+          <Button
+            onClick={handleSubmit}
+            disabled={createOrder.isPending || !state.clientId}
+          >
+            {createOrder.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Utwórz zamówienie
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/OrderStatusBadge.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/OrderStatusBadge.tsx
@@ -1,0 +1,12 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/OrderStatusBadge.tsx
+import { Badge } from '@/components/ui/badge';
+import type { CateringOrderStatus } from '@/types/catering-order.types';
+import { ORDER_STATUS_LABEL, ORDER_STATUS_COLOR } from '@/types/catering-order.types';
+
+export function OrderStatusBadge({ status }: { status: CateringOrderStatus }) {
+  return (
+    <Badge className={`${ORDER_STATUS_COLOR[status]}`} variant="outline">
+      {ORDER_STATUS_LABEL[status]}
+    </Badge>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/OrderTimeline.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/OrderTimeline.tsx
@@ -1,0 +1,79 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/OrderTimeline.tsx
+'use client';
+
+import { useCateringOrderHistory } from '@/hooks/use-catering-orders';
+import { Loader2, History } from 'lucide-react';
+import type { CateringOrderHistoryEntry } from '@/types/catering-order.types';
+import { ORDER_STATUS_LABEL } from '@/types/catering-order.types';
+
+const CHANGE_TYPE_LABEL: Record<string, string> = {
+  CREATED: 'Zamówienie utworzone',
+  STATUS_CHANGE: 'Zmiana statusu',
+  UPDATED: 'Zaktualizowano',
+};
+
+function formatDate(iso: string) {
+  return new Intl.DateTimeFormat('pl-PL', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(iso));
+}
+
+function entryLabel(entry: CateringOrderHistoryEntry) {
+  if (entry.changeType === 'STATUS_CHANGE' && entry.oldValue && entry.newValue) {
+    const from = ORDER_STATUS_LABEL[entry.oldValue as keyof typeof ORDER_STATUS_LABEL] ?? entry.oldValue;
+    const to = ORDER_STATUS_LABEL[entry.newValue as keyof typeof ORDER_STATUS_LABEL] ?? entry.newValue;
+    return `${from} → ${to}`;
+  }
+  if (entry.changeType === 'CREATED') {
+    return 'Zamówienie zostało utworzone';
+  }
+  return entry.newValue ?? '—';
+}
+
+export function OrderTimeline({ orderId }: { orderId: string }) {
+  const { data: history, isLoading } = useCateringOrderHistory(orderId);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground py-4">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        <span>Ładowanie historii...</span>
+      </div>
+    );
+  }
+
+  if (!history || history.length === 0) {
+    return <p className="text-sm text-muted-foreground py-4">Brak wpisów w historii</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold flex items-center gap-2">
+        <History className="h-4 w-4" /> Historia zmian
+      </h3>
+      <ol className="relative border-l border-border ml-3 space-y-4">
+        {history.map(entry => (
+          <li key={entry.id} className="ml-4">
+            <span className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full border border-background bg-muted-foreground" />
+            <p className="text-sm font-medium">
+              {CHANGE_TYPE_LABEL[entry.changeType] ?? entry.changeType}
+            </p>
+            <p className="text-sm text-muted-foreground">{entryLabel(entry)}</p>
+            {entry.reason && (
+              <p className="text-xs text-muted-foreground italic">Powód: {entry.reason}</p>
+            )}
+            <div className="flex items-center gap-2 mt-1">
+              <span className="text-xs text-muted-foreground">{formatDate(entry.createdAt)}</span>
+              {entry.changedBy && (
+                <span className="text-xs text-muted-foreground">
+                  · {entry.changedBy.firstName} {entry.changedBy.lastName}
+                </span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/OrdersFilters.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/OrdersFilters.tsx
@@ -1,0 +1,116 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/OrdersFilters.tsx
+'use client';
+
+import { useState } from 'react';
+import { Search, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { CateringOrdersFilter, CateringOrderStatus, CateringDeliveryType } from '@/types/catering-order.types';
+import { ORDER_STATUS_LABEL, DELIVERY_TYPE_LABEL } from '@/types/catering-order.types';
+
+interface Props {
+  filter: CateringOrdersFilter;
+  onChange: (partial: Partial<CateringOrdersFilter>) => void;
+}
+
+export function OrdersFilters({ filter, onChange }: Props) {
+  const [search, setSearch] = useState(filter.search ?? '');
+
+  const handleSearchSubmit = () => {
+    onChange({ search: search.trim() || undefined });
+  };
+
+  const handleReset = () => {
+    setSearch('');
+    onChange({ status: undefined, deliveryType: undefined, search: undefined, eventDateFrom: undefined, eventDateTo: undefined });
+  };
+
+  const hasActiveFilters =
+    filter.status || filter.deliveryType || filter.search || filter.eventDateFrom || filter.eventDateTo;
+
+  return (
+    <div className="flex flex-wrap gap-3 items-end">
+      {/* Szukaj */}
+      <div className="flex gap-2">
+        <Input
+          placeholder="Szukaj: nr, klient, wydarzenie..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSearchSubmit()}
+          className="w-64"
+        />
+        <Button variant="outline" size="icon" onClick={handleSearchSubmit}>
+          <Search className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Status */}
+      <Select
+        value={filter.status ?? 'ALL'}
+        onValueChange={v => onChange({ status: v === 'ALL' ? undefined : v as CateringOrderStatus })}
+      >
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Wszystkie statusy" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ALL">Wszystkie statusy</SelectItem>
+          {(Object.entries(ORDER_STATUS_LABEL) as [CateringOrderStatus, string][]).map(([v, l]) => (
+            <SelectItem key={v} value={v}>{l}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Typ dostawy */}
+      <Select
+        value={filter.deliveryType ?? 'ALL'}
+        onValueChange={v => onChange({ deliveryType: v === 'ALL' ? undefined : v as CateringDeliveryType })}
+      >
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Typ dostawy" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="ALL">Wszystkie typy</SelectItem>
+          {(Object.entries(DELIVERY_TYPE_LABEL) as [CateringDeliveryType, string][]).map(([v, l]) => (
+            <SelectItem key={v} value={v}>{l}</SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Data od */}
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-muted-foreground">Data od</span>
+        <Input
+          type="date"
+          value={filter.eventDateFrom ?? ''}
+          onChange={e => onChange({ eventDateFrom: e.target.value || undefined })}
+          className="w-40"
+        />
+      </div>
+
+      {/* Data do */}
+      <div className="flex flex-col gap-1">
+        <span className="text-xs text-muted-foreground">Data do</span>
+        <Input
+          type="date"
+          value={filter.eventDateTo ?? ''}
+          onChange={e => onChange({ eventDateTo: e.target.value || undefined })}
+          className="w-40"
+        />
+      </div>
+
+      {/* Reset */}
+      {hasActiveFilters && (
+        <Button variant="ghost" size="sm" onClick={handleReset}>
+          <X className="mr-1 h-3 w-3" /> Resetuj filtry
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/components/OrdersTable.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/components/OrdersTable.tsx
@@ -1,0 +1,136 @@
+// apps/frontend/src/app/dashboard/catering/orders/components/OrdersTable.tsx
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import type {
+  CateringOrderListItem,
+  CateringOrderStatus,
+} from '@/types/catering-order.types';
+import {
+  ORDER_STATUS_LABEL,
+  ORDER_STATUS_COLOR,
+  DELIVERY_TYPE_LABEL,
+} from '@/types/catering-order.types';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface Props {
+  orders: CateringOrderListItem[];
+  meta?: { total: number; page: number; limit: number; totalPages: number };
+  onPageChange: (page: number) => void;
+  onRowClick: (id: string) => void;
+}
+
+function formatPrice(value: number | string) {
+  return new Intl.NumberFormat('pl-PL', {
+    style: 'currency',
+    currency: 'PLN',
+  }).format(Number(value));
+}
+
+function clientName(order: CateringOrderListItem) {
+  if (order.client.clientType === 'COMPANY' && order.client.companyName)
+    return order.client.companyName;
+  return `${order.client.firstName} ${order.client.lastName}`;
+}
+
+export function OrdersTable({ orders, meta, onPageChange, onRowClick }: Props) {
+  if (orders.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16">
+        <p className="text-muted-foreground">Brak zamówień spełniających kryteria</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Numer</TableHead>
+              <TableHead>Klient</TableHead>
+              <TableHead>Wydarzenie</TableHead>
+              <TableHead>Data</TableHead>
+              <TableHead>Typ</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Kwota</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {orders.map(order => (
+              <TableRow
+                key={order.id}
+                className="cursor-pointer hover:bg-muted/50"
+                onClick={() => onRowClick(order.id)}
+              >
+                <TableCell className="font-mono text-sm font-medium">
+                  {order.orderNumber}
+                </TableCell>
+                <TableCell>{clientName(order)}</TableCell>
+                <TableCell className="max-w-[200px] truncate">
+                  {order.eventName ?? <span className="text-muted-foreground">—</span>}
+                </TableCell>
+                <TableCell>
+                  {order.eventDate ?? <span className="text-muted-foreground">—</span>}
+                </TableCell>
+                <TableCell>
+                  <span className="text-sm text-muted-foreground">
+                    {DELIVERY_TYPE_LABEL[order.deliveryType]}
+                  </span>
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    className={`text-xs ${ORDER_STATUS_COLOR[order.status as CateringOrderStatus]}`}
+                    variant="outline"
+                  >
+                    {ORDER_STATUS_LABEL[order.status as CateringOrderStatus]}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-right font-medium">
+                  {formatPrice(order.totalPrice)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Paginacja */}
+      {meta && meta.totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            Strona {meta.page} z {meta.totalPages} ({meta.total} wyników)
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={meta.page <= 1}
+              onClick={() => onPageChange(meta.page - 1)}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={meta.page >= meta.totalPages}
+              onClick={() => onPageChange(meta.page + 1)}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/new/page.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/new/page.tsx
@@ -1,0 +1,31 @@
+// apps/frontend/src/app/dashboard/catering/orders/new/page.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { NewOrderWizard } from '../components/NewOrderWizard';
+
+export default function NewCateringOrderPage() {
+  const router = useRouter();
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => router.push('/dashboard/catering/orders')}
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">Nowe zamówienie cateringowe</h1>
+          <p className="text-sm text-muted-foreground">Wypełnij formularz krok po kroku</p>
+        </div>
+      </div>
+      <NewOrderWizard onSuccess={(id) => router.push(`/dashboard/catering/orders/${id}`)} />
+    </div>
+  );
+}

--- a/apps/frontend/src/app/dashboard/catering/orders/page.tsx
+++ b/apps/frontend/src/app/dashboard/catering/orders/page.tsx
@@ -1,0 +1,64 @@
+// apps/frontend/src/app/dashboard/catering/orders/page.tsx
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { ShoppingBag, Plus, Loader2 } from 'lucide-react';
+import { useCateringOrders } from '@/hooks/use-catering-orders';
+import { Button } from '@/components/ui/button';
+import { OrdersTable } from './components/OrdersTable';
+import { OrdersFilters } from './components/OrdersFilters';
+import type { CateringOrdersFilter } from '@/types/catering-order.types';
+
+export default function CateringOrdersPage() {
+  const router = useRouter();
+  const [filter, setFilter] = useState<CateringOrdersFilter>({ page: 1, limit: 20 });
+
+  const { data, isLoading } = useCateringOrders(filter);
+
+  const handleFilterChange = (partial: Partial<CateringOrdersFilter>) => {
+    setFilter(prev => ({ ...prev, ...partial, page: 1 }));
+  };
+
+  const handlePageChange = (page: number) => {
+    setFilter(prev => ({ ...prev, page }));
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+            <ShoppingBag className="h-8 w-8" />
+            Zamówienia cateringowe
+          </h1>
+          <p className="text-muted-foreground">
+            Lista zamówień — {data?.meta?.total ?? 0} łącznie
+          </p>
+        </div>
+        <Button onClick={() => router.push('/dashboard/catering/orders/new')}>
+          <Plus className="mr-2 h-4 w-4" />
+          Nowe zamówienie
+        </Button>
+      </div>
+
+      {/* Filtry */}
+      <OrdersFilters filter={filter} onChange={handleFilterChange} />
+
+      {/* Tabela */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <OrdersTable
+          orders={data?.data ?? []}
+          meta={data?.meta}
+          onPageChange={handlePageChange}
+          onRowClick={(id) => router.push(`/dashboard/catering/orders/${id}`)}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/hooks/use-catering-orders.ts
+++ b/apps/frontend/src/hooks/use-catering-orders.ts
@@ -1,0 +1,163 @@
+// apps/frontend/src/hooks/use-catering-orders.ts
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import type {
+  CateringOrder,
+  CateringOrdersListResponse,
+  CateringOrdersFilter,
+  CreateCateringOrderInput,
+  UpdateCateringOrderInput,
+  ChangeStatusInput,
+  CreateDepositInput,
+  MarkDepositPaidInput,
+  CateringOrderHistoryEntry,
+} from '@/types/catering-order.types';
+
+const KEYS = {
+  orders: (filter?: CateringOrdersFilter) =>
+    ['catering-orders', filter ?? {}] as const,
+  order: (id: string) => ['catering-orders', id] as const,
+  history: (id: string) => ['catering-orders', id, 'history'] as const,
+};
+
+// ═══════════════════════════════════════════════════════════════
+// Queries
+// ═══════════════════════════════════════════════════════════════
+
+export function useCateringOrders(filter: CateringOrdersFilter = {}) {
+  return useQuery<CateringOrdersListResponse>({
+    queryKey: KEYS.orders(filter),
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (filter.status) params.set('status', filter.status);
+      if (filter.deliveryType) params.set('deliveryType', filter.deliveryType);
+      if (filter.clientId) params.set('clientId', filter.clientId);
+      if (filter.eventDateFrom) params.set('eventDateFrom', filter.eventDateFrom);
+      if (filter.eventDateTo) params.set('eventDateTo', filter.eventDateTo);
+      if (filter.search) params.set('search', filter.search);
+      if (filter.page) params.set('page', String(filter.page));
+      if (filter.limit) params.set('limit', String(filter.limit));
+      const qs = params.toString();
+      const res = await api.get(`/catering/orders${qs ? `?${qs}` : ''}`);
+      return res.data;
+    },
+    placeholderData: keepPreviousData,
+    staleTime: 5_000,
+  });
+}
+
+export function useCateringOrder(id: string) {
+  return useQuery<CateringOrder>({
+    queryKey: KEYS.order(id),
+    queryFn: async () => {
+      const res = await api.get(`/catering/orders/${id}`);
+      return res.data.data;
+    },
+    enabled: !!id,
+    staleTime: 5_000,
+  });
+}
+
+export function useCateringOrderHistory(id: string) {
+  return useQuery<CateringOrderHistoryEntry[]>({
+    queryKey: KEYS.history(id),
+    queryFn: async () => {
+      const res = await api.get(`/catering/orders/${id}/history`);
+      return res.data.data;
+    },
+    enabled: !!id,
+    staleTime: 10_000,
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Mutations
+// ═══════════════════════════════════════════════════════════════
+
+export function useCreateCateringOrder() {
+  const qc = useQueryClient();
+  return useMutation<CateringOrder, Error, CreateCateringOrderInput>({
+    mutationFn: async (data) => {
+      const res = await api.post('/catering/orders', data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['catering-orders'] });
+    },
+  });
+}
+
+export function useUpdateCateringOrder(id: string) {
+  const qc = useQueryClient();
+  return useMutation<CateringOrder, Error, UpdateCateringOrderInput>({
+    mutationFn: async (data) => {
+      const res = await api.patch(`/catering/orders/${id}`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: KEYS.order(id) });
+      await qc.invalidateQueries({ queryKey: ['catering-orders'] });
+    },
+  });
+}
+
+export function useChangeCateringOrderStatus(id: string) {
+  const qc = useQueryClient();
+  return useMutation<CateringOrder, Error, ChangeStatusInput>({
+    mutationFn: async (data) => {
+      const res = await api.patch(`/catering/orders/${id}/status`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: KEYS.order(id) });
+      await qc.invalidateQueries({ queryKey: KEYS.history(id) });
+      await qc.invalidateQueries({ queryKey: ['catering-orders'] });
+    },
+  });
+}
+
+export function useDeleteCateringOrder() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, string>({
+    mutationFn: async (id) => {
+      await api.delete(`/catering/orders/${id}`);
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: ['catering-orders'] });
+    },
+  });
+}
+
+export function useCreateCateringDeposit(orderId: string) {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, CreateDepositInput>({
+    mutationFn: async (data) => {
+      const res = await api.post(`/catering/orders/${orderId}/deposits`, data);
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: KEYS.order(orderId) });
+    },
+  });
+}
+
+export function useMarkDepositPaid(orderId: string, depositId: string) {
+  const qc = useQueryClient();
+  return useMutation<unknown, Error, MarkDepositPaidInput>({
+    mutationFn: async (data) => {
+      const res = await api.patch(
+        `/catering/orders/${orderId}/deposits/${depositId}/pay`,
+        data,
+      );
+      return res.data.data;
+    },
+    onSuccess: async () => {
+      await qc.invalidateQueries({ queryKey: KEYS.order(orderId) });
+    },
+  });
+}

--- a/apps/frontend/src/types/catering-order.types.ts
+++ b/apps/frontend/src/types/catering-order.types.ts
@@ -1,0 +1,260 @@
+// apps/frontend/src/types/catering-order.types.ts
+// Faza 2 — Zamówienia cateringowe (#150)
+
+export type CateringOrderStatus =
+  | 'DRAFT'
+  | 'INQUIRY'
+  | 'QUOTED'
+  | 'CONFIRMED'
+  | 'IN_PREPARATION'
+  | 'READY'
+  | 'DELIVERED'
+  | 'COMPLETED'
+  | 'CANCELLED';
+
+export type CateringDeliveryType = 'PICKUP' | 'DELIVERY' | 'ON_SITE';
+export type CateringDiscountType = 'PERCENTAGE' | 'AMOUNT';
+
+export const ORDER_STATUS_LABEL: Record<CateringOrderStatus, string> = {
+  DRAFT: 'Szkic',
+  INQUIRY: 'Zapytanie',
+  QUOTED: 'Oferta wysłana',
+  CONFIRMED: 'Potwierdzone',
+  IN_PREPARATION: 'W przygotowaniu',
+  READY: 'Gotowe',
+  DELIVERED: 'Dostarczone',
+  COMPLETED: 'Zakończone',
+  CANCELLED: 'Anulowane',
+};
+
+export const ORDER_STATUS_COLOR: Record<CateringOrderStatus, string> = {
+  DRAFT: 'bg-gray-100 text-gray-700',
+  INQUIRY: 'bg-blue-100 text-blue-700',
+  QUOTED: 'bg-purple-100 text-purple-700',
+  CONFIRMED: 'bg-green-100 text-green-700',
+  IN_PREPARATION: 'bg-orange-100 text-orange-700',
+  READY: 'bg-emerald-100 text-emerald-700',
+  DELIVERED: 'bg-teal-100 text-teal-700',
+  COMPLETED: 'bg-slate-100 text-slate-700',
+  CANCELLED: 'bg-red-100 text-red-700',
+};
+
+export const DELIVERY_TYPE_LABEL: Record<CateringDeliveryType, string> = {
+  PICKUP: 'Odbiór własny',
+  DELIVERY: 'Dostawa',
+  ON_SITE: 'Na miejscu',
+};
+
+// ─── Modele odpowiedzi ────────────────────────────────────────
+
+export interface CateringOrderClient {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email?: string | null;
+  phone?: string;
+  companyName?: string | null;
+  clientType: 'INDIVIDUAL' | 'COMPANY';
+}
+
+export interface CateringOrderCreatedBy {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+}
+
+export interface CateringOrderItem {
+  id: string;
+  dishId: string;
+  dishNameSnapshot: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+  note?: string | null;
+  dish?: { id: string; name: string };
+}
+
+export interface CateringOrderExtra {
+  id: string;
+  name: string;
+  description?: string | null;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+}
+
+export interface CateringOrderHistoryEntry {
+  id: string;
+  changeType: string;
+  fieldName?: string | null;
+  oldValue?: string | null;
+  newValue?: string | null;
+  reason?: string | null;
+  createdAt: string;
+  changedBy?: { id: string; firstName: string; lastName: string };
+}
+
+export interface CateringDeposit {
+  id: string;
+  amount: number;
+  paidAmount: number;
+  remainingAmount: number;
+  dueDate: string;
+  status: string;
+  paid: boolean;
+  paidAt?: string | null;
+  paymentMethod?: string | null;
+  title?: string | null;
+  description?: string | null;
+  createdAt: string;
+}
+
+export interface CateringOrder {
+  id: string;
+  orderNumber: string;
+  status: CateringOrderStatus;
+  deliveryType: CateringDeliveryType;
+
+  client: CateringOrderClient;
+  createdBy: CateringOrderCreatedBy;
+
+  templateId?: string | null;
+  packageId?: string | null;
+  template?: { id: string; name: string; slug: string } | null;
+  package?: { id: string; name: string; basePrice: number } | null;
+
+  eventName?: string | null;
+  eventDate?: string | null;
+  eventTime?: string | null;
+  eventLocation?: string | null;
+  guestsCount: number;
+
+  deliveryAddress?: string | null;
+  deliveryNotes?: string | null;
+  deliveryDate?: string | null;
+  deliveryTime?: string | null;
+
+  subtotal: number;
+  extrasTotalPrice: number;
+  discountType?: CateringDiscountType | null;
+  discountValue?: number | null;
+  discountAmount?: number | null;
+  discountReason?: string | null;
+  totalPrice: number;
+
+  contactName?: string | null;
+  contactPhone?: string | null;
+  contactEmail?: string | null;
+
+  notes?: string | null;
+  internalNotes?: string | null;
+  specialRequirements?: string | null;
+  quoteExpiresAt?: string | null;
+
+  items: CateringOrderItem[];
+  extras: CateringOrderExtra[];
+  deposits: CateringDeposit[];
+
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ─── Lista (uproszczona) ────────────────────────────────────────
+
+export interface CateringOrderListItem {
+  id: string;
+  orderNumber: string;
+  status: CateringOrderStatus;
+  deliveryType: CateringDeliveryType;
+  eventDate?: string | null;
+  eventName?: string | null;
+  guestsCount: number;
+  totalPrice: number;
+  client: Pick<CateringOrderClient, 'id' | 'firstName' | 'lastName' | 'companyName' | 'clientType'>;
+  _count?: { items: number; deposits: number };
+  createdAt: string;
+}
+
+export interface CateringOrdersListResponse {
+  data: CateringOrderListItem[];
+  meta: { total: number; page: number; limit: number; totalPages: number };
+}
+
+// ─── Filtry ────────────────────────────────────────────────────
+
+export interface CateringOrdersFilter {
+  status?: CateringOrderStatus;
+  deliveryType?: CateringDeliveryType;
+  clientId?: string;
+  eventDateFrom?: string;
+  eventDateTo?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+// ─── Inputy (create / update) ──────────────────────────────────
+
+export interface CreateOrderItemInput {
+  dishId: string;
+  quantity: number;
+  unitPrice: number;
+  note?: string | null;
+}
+
+export interface CreateOrderExtraInput {
+  name: string;
+  description?: string | null;
+  quantity: number;
+  unitPrice: number;
+}
+
+export interface CreateCateringOrderInput {
+  clientId: string;
+  templateId?: string | null;
+  packageId?: string | null;
+  deliveryType?: CateringDeliveryType;
+  eventName?: string | null;
+  eventDate?: string | null;
+  eventTime?: string | null;
+  eventLocation?: string | null;
+  guestsCount?: number;
+  deliveryAddress?: string | null;
+  deliveryNotes?: string | null;
+  deliveryDate?: string | null;
+  deliveryTime?: string | null;
+  discountType?: CateringDiscountType | null;
+  discountValue?: number | null;
+  discountReason?: string | null;
+  contactName?: string | null;
+  contactPhone?: string | null;
+  contactEmail?: string | null;
+  notes?: string | null;
+  internalNotes?: string | null;
+  specialRequirements?: string | null;
+  quoteExpiresAt?: string | null;
+  items?: CreateOrderItemInput[];
+  extras?: CreateOrderExtraInput[];
+}
+
+export interface UpdateCateringOrderInput extends Partial<Omit<CreateCateringOrderInput, 'clientId'>> {
+  changeReason?: string | null;
+}
+
+export interface ChangeStatusInput {
+  status: CateringOrderStatus;
+  reason?: string | null;
+}
+
+export interface CreateDepositInput {
+  amount: number;
+  dueDate: string;
+  title?: string | null;
+  description?: string | null;
+  internalNotes?: string | null;
+}
+
+export interface MarkDepositPaidInput {
+  paymentMethod?: 'CASH' | 'TRANSFER' | 'BLIK' | 'CARD';
+}


### PR DESCRIPTION
## Co zostało dodane

### Typy
- `types/catering-order.types.ts` — pełne typy TS dla zamówień, status/delivery labelki i kolory

### Hook
- `hooks/use-catering-orders.ts` — TanStack Query: list (z filtrami + paginacją), single, historia, create, update, changeStatus, delete, createDeposit, markDepositPaid

### Strony (App Router)
| Ścieżka | Opis |
|---|---|
| `/dashboard/catering/orders` | Lista z filtrami i paginacją |
| `/dashboard/catering/orders/new` | Wielokrokowy formularz (6 kroków) |
| `/dashboard/catering/orders/[id]` | Szczegóły: dania, extras, finanse, depozyty, historia |

### Komponenty
| Plik | Opis |
|---|---|
| `OrdersTable` | Tabela z paginacją, kliknięcie → szczegóły |
| `OrdersFilters` | Status, typ dostawy, daty, wyszukiwarka |
| `OrderStatusBadge` | Kolorowy badge statusu |
| `OrderTimeline` | Historia zmian (stepper-style) |
| `ChangeStatusDialog` | Dialog zmiany statusu z powodem |
| `NewOrderWizard` | 6-krokowy formularz tworzenia zamówienia |

## Deploy
```bash
git pull origin main  # poczekaj na merge
make prod-build
```

Frontend tylko — brak zmian w backend/prisma.