### PR TITLE
feat(rbac+nav): catering:manage_orders & catering:manage_deposits + sidebar Zamówienia

### DIFF
--- a/apps/backend/src/constants/permissions.ts
+++ b/apps/backend/src/constants/permissions.ts
@@ -51,6 +51,8 @@ export const ACTION_LABELS: Record<string, string> = {
   history: 'Historia zmian',
   manage_catering_templates: 'Szablony cateringu',
   manage_catering_packages: 'Pakiety cateringu',
+  manage_orders: 'Zamówienia cateringowe',
+  manage_deposits: 'Depozyty zamówień cateringowych',
 };
 
 // ================================================================
@@ -95,6 +97,8 @@ export const PERMISSION_DEFINITIONS: PermissionTuple[] = [
   ['catering:read',                     'catering', 'read',                     'Catering — przeglądanie',        'Pogląd szablonów i pakietów cateringu'],
   ['catering:manage_catering_templates','catering', 'manage_catering_templates', 'Catering — szablony',            'Tworzenie i edycja szablonów cateringu'],
   ['catering:manage_catering_packages', 'catering', 'manage_catering_packages',  'Catering — pakiety',             'Tworzenie i edycja pakietów cateringu'],
+  ['catering:manage_orders',            'catering', 'manage_orders',             'Catering — zamówienia',          'Tworzenie i zarządzanie zamówieniami cateringowymi'],
+  ['catering:manage_deposits',          'catering', 'manage_deposits',           'Catering — depozyty',            'Zarządzanie depozytami zamówień cateringowych'],
 
   // ╣╗╗ Queue ╣╗╗
   ['queue:read',   'queue', 'read',   'Kolejka — przeglądanie',  'Pogląd kolejki rezerwacji'],
@@ -181,6 +185,7 @@ export const ROLE_DEFINITIONS: Record<string, RoleDefinition> = {
       'menu:manage_dishes', 'menu:manage_categories', 'menu:manage_addon_groups',
       // Catering — full
       'catering:read', 'catering:manage_catering_templates', 'catering:manage_catering_packages',
+      'catering:manage_orders', 'catering:manage_deposits',
       // Queue
       'queue:read', 'queue:manage',
       // Deposits — full
@@ -218,8 +223,8 @@ export const ROLE_DEFINITIONS: Record<string, RoleDefinition> = {
       'halls:read',
       // Menu — read
       'menu:read',
-      // Catering — read
-      'catering:read',
+      // Catering — read + manage orders
+      'catering:read', 'catering:manage_orders',
       // Queue — read
       'queue:read',
       // Deposits — create + mark paid

--- a/apps/frontend/src/app/dashboard/components/DashboardNav.tsx
+++ b/apps/frontend/src/app/dashboard/components/DashboardNav.tsx
@@ -16,6 +16,7 @@ import {
   X,
   Building2,
   UtensilsCrossed,
+  ClipboardList,
 } from 'lucide-react';
 
 // ── Nav item types ─────────────────────────────────────
@@ -42,6 +43,11 @@ const NAV_ITEMS: NavItem[] = [
         label: 'Szablony',
         href: '/dashboard/catering/templates',
         icon: <UtensilsCrossed className="h-4 w-4" />,
+      },
+      {
+        label: 'Zamówienia',
+        href: '/dashboard/catering/orders',
+        icon: <ClipboardList className="h-4 w-4" />,
       },
     ],
   },


### PR DESCRIPTION
## Co zmienia ten PR

Uzupełnia brakujące elementy **Fazy 2 Catering** (zamówienia cateringowe).
Backend (migracja, serwis, kontroler, routes) jest już na `main` — ten PR dodaje tylko brakujące RBAC i link w sidebarze.

---

### 1. RBAC — `apps/backend/src/constants/permissions.ts`

#### Nowe uprawnienia (2)
| slug | moduł | akcja | opis |
|---|---|---|---|
| `catering:manage_orders` | catering | manage_orders | Tworzenie i zarządzanie zamówieniami cateringowymi |
| `catering:manage_deposits` | catering | manage_deposits | Zarządzanie depozytami zamówień cateringowych |

#### Przypisanie do ról
| Rola | `catering:manage_orders` | `catering:manage_deposits` |
|---|---|---|
| **admin** | ✅ (ALL) | ✅ (ALL) |
| **manager** | ✅ | ✅ |
| **employee** | ✅ | ❌ |
| **viewer** | ❌ | ❌ |

> Po merge: `npx prisma db seed` odświeży uprawnienia przez `upsert` — zero downtime.

---

### 2. Sidebar — `apps/frontend/src/app/dashboard/components/DashboardNav.tsx`

- Dodano `ClipboardList` do importów z `lucide-react`
- Dodano pozycję **Zamówienia** (`/dashboard/catering/orders`) jako drugie dziecko sekcji Catering (po Szablonach)

```
Catering
├── Szablony
└── Zamówienia  ← NOWE
```

---

### Checklist
- [x] `catering:manage_orders` dodane do PERMISSION_DEFINITIONS
- [x] `catering:manage_deposits` dodane do PERMISSION_DEFINITIONS
- [x] `manage_orders` / `manage_deposits` dodane do ACTION_LABELS
- [x] Uprawnienia przypisane do ról manager + employee
- [x] Sidebar — link `/dashboard/catering/orders`
- [x] Import `ClipboardList` z lucide-react

---

### Po merge — kroki na dev
```bash
make dev-down && make dev-build
# lub tylko:
npx prisma db seed   # dorzuci 2 nowe uprawnienia przez upsert
```

Związane z issues Fazy 2 cateringu.