### PR TITLE
fix(routes): GET /api/dishes/category/:categoryId niedostępny — route shadowing przez /:id

### DIFF
--- a/apps/backend/src/routes/dish.routes.ts
+++ b/apps/backend/src/routes/dish.routes.ts
@@ -12,6 +12,7 @@ import { validateUUID } from '../middlewares/validateUUID';
 
 const router = Router();
 
+// GET /api/dishes
 router.get(
   '/',
   asyncHandler(async (req, res) => {
@@ -19,14 +20,8 @@ router.get(
   })
 );
 
-router.get(
-  '/:id',
-  validateUUID('id'),
-  asyncHandler(async (req, res) => {
-    await dishController.getDishById(req, res);
-  })
-);
-
+// GET /api/dishes/category/:categoryId
+// NOTE: must be registered BEFORE /:id to prevent route shadowing by Express
 router.get(
   '/category/:categoryId',
   validateUUID('categoryId'),
@@ -35,6 +30,16 @@ router.get(
   })
 );
 
+// GET /api/dishes/:id
+router.get(
+  '/:id',
+  validateUUID('id'),
+  asyncHandler(async (req, res) => {
+    await dishController.getDishById(req, res);
+  })
+);
+
+// POST /api/dishes
 router.post(
   '/',
   authMiddleware,
@@ -44,6 +49,7 @@ router.post(
   })
 );
 
+// PUT /api/dishes/:id
 router.put(
   '/:id',
   authMiddleware,
@@ -54,6 +60,7 @@ router.put(
   })
 );
 
+// DELETE /api/dishes/:id
 router.delete(
   '/:id',
   authMiddleware,


### PR DESCRIPTION
## 🐛 Bug fix — `dish.routes.ts` route ordering

### Problem

Express dopasowuje route'y **w kolejności rejestracji**. W poprzedniej wersji `dish.routes.ts`:

```
GET /          ← OK
GET /:id       ← 🔴 rejestracja 2. — przechwytuje /category/uuid jako id='category'
GET /category/:categoryId  ← 🟡 NIEOSIAGALNY — nigdy nie docieramy tutaj
```

Kiedy klient wysyła `GET /api/dishes/category/some-uuid`, Express dopasowuje `/:id` z `id = 'category'`, następnie `validateUUID('id')` odrzuca request z `400 Bad Request` (ponieważ `'category'` nie jest UUID).

### Fix

Prześwietlony route `/category/:categoryId` przeniesiony **przed** `/:id`:

```
GET /                    ← OK
GET /category/:categoryId  ← ✅ rejestracja 2. (PRZED /:id)
GET /:id                 ← ✅ rejestracja 3.
```

Ten sam wzorzec już poprawnie zastosowany w `dish-category.routes.ts` (`/slug/:slug` przed `/:id`).

### Wpływ

- `GET /api/dishes/category/:categoryId` — od tej chwili działa prawidłowo
- `OptionManager.tsx` (catering package builder) może teraz korzystać z endpointów filtrowanych zamiast pobierać wszystkie dania
- Żadnych zmian schematu Prisma ani migracji

### ✅ Checklist
- [x] Jedna zmiana — kolejność route'u w `dish.routes.ts`
- [x] Backward compatible — `GET /` i `GET /:id` działają bez zmian
- [x] Dodano komentarze przy każdym route dla jasności

### 🚀 Deploy — komendy po merge
```bash
git pull origin main
docker restart rezerwacje-api-dev
# prod:
docker restart rezerwacje-api
```
> Brak migracji Prisma — tylko zmiana kolejności routeów.