### PR TITLE
fix(catering): brak page.tsx przy /dashboard/catering — redirect do /templates

### DIFF
--- a/apps/frontend/src/app/dashboard/catering/page.tsx
+++ b/apps/frontend/src/app/dashboard/catering/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * /dashboard/catering — redirectuje do /dashboard/catering/templates
+ * Sidebar linkuje do tego URL jako root sekcji Catering.
+ */
+export default function CateringRootPage() {
+  redirect('/dashboard/catering/templates');
+}


### PR DESCRIPTION
## Problem

Sidebar w `DashboardNav.tsx` ma wpis:
```ts
{
  label: 'Catering',
  href: '/dashboard/catering',   // ← ten URL nie miał page.tsx
  children: [
    { label: 'Szablony', href: '/dashboard/catering/templates' },
    { label: 'Zamówienia', href: '/dashboard/catering/orders' },
  ]
}
```

Kliknięcie rozwiniętej sekcji powodowało 404 ponieważ `/dashboard/catering` nie miało `page.tsx`.

## Fix

Dodano `apps/frontend/src/app/dashboard/catering/page.tsx` z natychmiastowym `redirect('/dashboard/catering/templates')`.

Jest to Next.js server-side redirect (`next/navigation`) — nie renderuje żadnego UI, tylko przekierowuje.