### PR TITLE
fix(ui): alert-dialog — usuń import buttonVariants z niescommitowanego button.tsx

### DIFF
--- a/apps/frontend/src/components/ui/alert-dialog.tsx
+++ b/apps/frontend/src/components/ui/alert-dialog.tsx
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 import { cn } from '@/lib/utils';
-import { buttonVariants } from '@/components/ui/button';
+
+// Inline button styles — nie importujemy buttonVariants z button.tsx
+// ponieważ button.tsx nie jest w git i może nie eksportować buttonVariants.
+const actionCls =
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2';
+const cancelCls =
+  'inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 mt-2 sm:mt-0';
 
 const AlertDialog = AlertDialogPrimitive.Root;
-
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
-
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
@@ -47,10 +51,7 @@ const AlertDialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      'flex flex-col space-y-2 text-center sm:text-left',
-      className,
-    )}
+    className={cn('flex flex-col space-y-2 text-center sm:text-left', className)}
     {...props}
   />
 );
@@ -92,8 +93,7 @@ const AlertDialogDescription = React.forwardRef<
     {...props}
   />
 ));
-AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName;
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -101,7 +101,7 @@ const AlertDialogAction = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Action
     ref={ref}
-    className={cn(buttonVariants(), className)}
+    className={cn(actionCls, className)}
     {...props}
   />
 ));
@@ -113,11 +113,7 @@ const AlertDialogCancel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Cancel
     ref={ref}
-    className={cn(
-      buttonVariants({ variant: 'outline' }),
-      'mt-2 sm:mt-0',
-      className,
-    )}
+    className={cn(cancelCls, className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Problem

`alert-dialog.tsx` (PR #188) importował:
```ts
import { buttonVariants } from '@/components/ui/button';
```

`button.tsx` **nie jest w git** — istnieje tylko lokalnie na serwerze. Jeśli ta lokalna wersja nie eksportuje `buttonVariants` (starsze wersje shadcn/ui), to `alert-dialog.tsx` fałszował import, co powodowało cichy 404 w Next.js 14.

## Fix

Zastąpiono `buttonVariants()` inline'owymi klasami Tailwind dla `AlertDialogAction` i `AlertDialogCancel`. `alert-dialog.tsx` jest teraz w pełni self-contained — nie ma żadnej zależności od niescommitowanych komponentów.