### PR TITLE
feat: UI rabatów i depozytów w szczegółach zamówienia cateringowego

### DIFF
--- a/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
@@ -27,8 +27,13 @@ import {
   Sparkles,
   ChevronRight,
   History,
+  Plus,
+  Pencil,
 } from 'lucide-react';
-import { useCateringOrder, useDeleteCateringOrder } from '@/hooks/use-catering-orders';
+import {
+  useCateringOrder,
+  useDeleteCateringOrder,
+} from '@/hooks/use-catering-orders';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -41,7 +46,11 @@ import {
 import { OrderStatusBadge } from '../components/OrderStatusBadge';
 import { OrderTimeline } from '../components/OrderTimeline';
 import { ChangeStatusDialog } from '../components/ChangeStatusDialog';
+import { DiscountDialog } from '../components/DiscountDialog';
+import { AddDepositDialog } from '../components/AddDepositDialog';
+import { MarkDepositPaidDialog } from '../components/MarkDepositPaidDialog';
 import { DELIVERY_TYPE_LABEL } from '@/types/catering-order.types';
+import type { CateringDeposit } from '@/types/catering-order.types';
 
 // ═══ HELPERS ═══
 
@@ -63,7 +72,11 @@ function formatDatePl(iso: string | null | undefined) {
   }
 }
 
-function getInitials(firstName?: string | null, lastName?: string | null, companyName?: string | null) {
+function getInitials(
+  firstName?: string | null,
+  lastName?: string | null,
+  companyName?: string | null,
+) {
   if (companyName) return companyName.slice(0, 2).toUpperCase();
   const f = firstName?.[0] ?? '';
   const l = lastName?.[0] ?? '';
@@ -72,7 +85,15 @@ function getInitials(firstName?: string | null, lastName?: string | null, compan
 
 // ═══ SUB-COMPONENTS ═══
 
-function StatPill({ icon: Icon, label, value }: { icon: React.ElementType; label?: string; value: string }) {
+function StatPill({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ElementType;
+  label?: string;
+  value: string;
+}) {
   return (
     <div className="flex items-center gap-2 bg-white/15 backdrop-blur-sm rounded-xl px-4 py-2 border border-white/20">
       <Icon className="w-4 h-4 shrink-0" />
@@ -100,14 +121,22 @@ function SectionCard({
   className?: string;
 }) {
   return (
-    <Card className={`border-0 shadow-sm ring-1 ring-neutral-200/60 dark:ring-neutral-700/60 overflow-hidden ${className ?? ''}`}>
+    <Card
+      className={`border-0 shadow-sm ring-1 ring-neutral-200/60 dark:ring-neutral-700/60 overflow-hidden ${
+        className ?? ''
+      }`}
+    >
       <CardHeader className="pb-3 pt-5 px-5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className={`w-10 h-10 rounded-xl ${iconBg} flex items-center justify-center shrink-0`}>
+            <div
+              className={`w-10 h-10 rounded-xl ${iconBg} flex items-center justify-center shrink-0`}
+            >
               <Icon className={`w-5 h-5 ${iconColor}`} />
             </div>
-            <CardTitle className="text-base font-semibold text-neutral-900 dark:text-neutral-100">{title}</CardTitle>
+            <CardTitle className="text-base font-semibold text-neutral-900 dark:text-neutral-100">
+              {title}
+            </CardTitle>
           </div>
           {badge}
         </div>
@@ -117,11 +146,23 @@ function SectionCard({
   );
 }
 
-function Field({ label, value, full }: { label: string; value?: string | null; full?: boolean }) {
+function Field({
+  label,
+  value,
+  full,
+}: {
+  label: string;
+  value?: string | null;
+  full?: boolean;
+}) {
   return (
     <div className={full ? 'col-span-2' : ''}>
-      <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-1">{label}</p>
-      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">{value ?? '—'}</p>
+      <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-1">
+        {label}
+      </p>
+      <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+        {value ?? '—'}
+      </p>
     </div>
   );
 }
@@ -139,7 +180,14 @@ function CountBadge({ count }: { count: number }) {
 export default function CateringOrderDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
+
   const [statusDialogOpen, setStatusDialogOpen] = useState(false);
+  const [discountDialogOpen, setDiscountDialogOpen] = useState(false);
+  const [depositDialogOpen, setDepositDialogOpen] = useState(false);
+  const [payingDeposit, setPayingDeposit] = useState<Pick<
+    CateringDeposit,
+    'id' | 'amount' | 'title'
+  > | null>(null);
 
   const { data: order, isLoading } = useCateringOrder(id);
   const deleteMutation = useDeleteCateringOrder();
@@ -154,7 +202,9 @@ export default function CateringOrderDetailPage() {
     return (
       <div className="flex flex-col items-center justify-center py-32 gap-4">
         <Loader2 className="h-10 w-10 animate-spin text-primary-500" />
-        <p className="text-sm text-neutral-500 dark:text-neutral-400">Wczytywanie zamówienia…</p>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">
+          Wczytywanie zamówienia…
+        </p>
       </div>
     );
   }
@@ -163,8 +213,13 @@ export default function CateringOrderDetailPage() {
     return (
       <div className="flex flex-col items-center justify-center py-32 gap-4">
         <AlertCircle className="h-12 w-12 text-neutral-300" />
-        <p className="font-semibold text-neutral-600 dark:text-neutral-400">Zamówienie nie istnieje</p>
-        <Button variant="outline" onClick={() => router.push('/dashboard/catering/orders')}>
+        <p className="font-semibold text-neutral-600 dark:text-neutral-400">
+          Zamówienie nie istnieje
+        </p>
+        <Button
+          variant="outline"
+          onClick={() => router.push('/dashboard/catering/orders')}
+        >
           <ArrowLeft className="mr-2 h-4 w-4" /> Powrót do listy
         </Button>
       </div>
@@ -183,8 +238,8 @@ export default function CateringOrderDetailPage() {
 
   const canDelete = order.status === 'DRAFT' || order.status === 'CANCELLED';
 
-  const items = order.items ?? [];
-  const extras = order.extras ?? [];
+  const items    = order.items    ?? [];
+  const extras   = order.extras   ?? [];
   const deposits = order.deposits ?? [];
 
   const pricePerGuest =
@@ -192,17 +247,17 @@ export default function CateringOrderDetailPage() {
       ? Number(order.totalPrice) / order.guestsCount
       : null;
 
+  const hasDiscount = !!order.discountType;
+
   return (
     <div className="min-h-0">
       {/* ═══ HERO ═══ */}
       <div className="relative overflow-hidden bg-gradient-to-br from-orange-500 via-amber-500 to-orange-600 px-6 py-8 text-white">
-        {/* Decorative blobs */}
         <div className="pointer-events-none absolute -right-16 -top-16 h-56 w-56 rounded-full bg-white/10" />
         <div className="pointer-events-none absolute -bottom-10 -left-10 h-40 w-40 rounded-full bg-white/5" />
         <div className="pointer-events-none absolute right-32 bottom-0 h-24 w-24 rounded-full bg-white/5" />
 
         <div className="relative max-w-7xl mx-auto">
-          {/* Top row */}
           <div className="flex items-start justify-between gap-4 mb-6">
             <button
               onClick={() => router.push('/dashboard/catering/orders')}
@@ -224,13 +279,19 @@ export default function CateringOrderDetailPage() {
                 size="sm"
                 variant="ghost"
                 className="text-white/90 hover:text-white hover:bg-white/20 border border-white/30 h-9 px-4"
-                onClick={() => router.push(`/dashboard/catering/orders/${id}/edit`)}
+                onClick={() =>
+                  router.push(`/dashboard/catering/orders/${id}/edit`)
+                }
               >
                 <Edit className="mr-1.5 h-3.5 w-3.5" /> Edytuj
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button size="sm" variant="ghost" className="text-white/90 hover:text-white hover:bg-white/20 border border-white/30 h-9 w-9 p-0">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="text-white/90 hover:text-white hover:bg-white/20 border border-white/30 h-9 w-9 p-0"
+                  >
                     <MoreVertical className="h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -248,7 +309,6 @@ export default function CateringOrderDetailPage() {
             </div>
           </div>
 
-          {/* Order number + status */}
           <div className="flex items-center gap-3 mb-2">
             <span className="font-mono text-white/60 text-sm tracking-wide">
               {order.orderNumber}
@@ -256,22 +316,35 @@ export default function CateringOrderDetailPage() {
             <OrderStatusBadge status={order.status} />
           </div>
 
-          {/* Event name */}
           <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mb-6">
             {order.eventName ?? 'Zamówienie cateringowe'}
           </h1>
 
-          {/* Stat pills */}
           <div className="flex flex-wrap gap-3">
             {order.eventDate && (
-              <StatPill icon={CalendarDays} label="Data" value={formatDatePl(order.eventDate)} />
+              <StatPill
+                icon={CalendarDays}
+                label="Data"
+                value={formatDatePl(order.eventDate)}
+              />
             )}
             <StatPill icon={Users} label="Osób" value={String(order.guestsCount)} />
-            <StatPill icon={Receipt} label="Wartość" value={formatPrice(order.totalPrice)} />
+            <StatPill
+              icon={Receipt}
+              label="Wartość"
+              value={formatPrice(order.totalPrice)}
+            />
             {pricePerGuest !== null && (
-              <StatPill icon={Sparkles} label="/ os." value={formatPrice(pricePerGuest)} />
+              <StatPill
+                icon={Sparkles}
+                label="/ os."
+                value={formatPrice(pricePerGuest)}
+              />
             )}
-            <StatPill icon={Truck} value={DELIVERY_TYPE_LABEL[order.deliveryType]} />
+            <StatPill
+              icon={Truck}
+              value={DELIVERY_TYPE_LABEL[order.deliveryType]}
+            />
           </div>
         </div>
       </div>
@@ -280,10 +353,9 @@ export default function CateringOrderDetailPage() {
       <div className="max-w-7xl mx-auto p-6">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
 
-          {/* LEFT COLUMN — 2/3 */}
+          {/* LEFT COLUMN */}
           <div className="lg:col-span-2 space-y-6">
 
-            {/* Wydarzenie — data realizacji usunięta (widoczna w bannerze i logistyce) */}
             <SectionCard
               icon={CalendarDays}
               iconBg="bg-orange-100 dark:bg-orange-900/30"
@@ -292,11 +364,15 @@ export default function CateringOrderDetailPage() {
             >
               <div className="grid grid-cols-2 gap-x-6 gap-y-5">
                 <Field label="Okazja" value={order.eventName} />
-                <Field label="Liczba osób" value={order.guestsCount ? `${order.guestsCount} osób` : '—'} />
+                <Field
+                  label="Liczba osób"
+                  value={
+                    order.guestsCount ? `${order.guestsCount} osób` : '—'
+                  }
+                />
               </div>
             </SectionCard>
 
-            {/* Logistyka */}
             <SectionCard
               icon={Truck}
               iconBg="bg-rose-100 dark:bg-rose-900/30"
@@ -312,15 +388,20 @@ export default function CateringOrderDetailPage() {
                 </div>
 
                 <div className="grid grid-cols-2 gap-x-6 gap-y-5">
-                  {(order.deliveryType === 'DELIVERY' || order.deliveryType === 'ON_SITE') &&
+                  {(order.deliveryType === 'DELIVERY' ||
+                    order.deliveryType === 'ON_SITE') &&
                     order.deliveryAddress && (
                       <div className="col-span-2">
                         <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-2">
-                          {order.deliveryType === 'DELIVERY' ? 'Adres dostawy' : 'Adres klienta'}
+                          {order.deliveryType === 'DELIVERY'
+                            ? 'Adres dostawy'
+                            : 'Adres klienta'}
                         </p>
                         <div className="flex items-start gap-2">
                           <MapPin className="w-4 h-4 text-neutral-400 shrink-0 mt-0.5" />
-                          <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">{order.deliveryAddress}</p>
+                          <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                            {order.deliveryAddress}
+                          </p>
                         </div>
                       </div>
                     )}
@@ -328,30 +409,40 @@ export default function CateringOrderDetailPage() {
                   {order.deliveryTime && (
                     <div>
                       <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-1">
-                        {order.deliveryType === 'PICKUP' ? 'Godzina odbioru' : 'Godzina'}
+                        {order.deliveryType === 'PICKUP'
+                          ? 'Godzina odbioru'
+                          : 'Godzina'}
                       </p>
                       <div className="flex items-center gap-2">
                         <Clock className="w-4 h-4 text-neutral-400" />
-                        <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">{order.deliveryTime}</p>
+                        <p className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                          {order.deliveryTime}
+                        </p>
                       </div>
                     </div>
                   )}
 
                   {order.deliveryDate && (
-                    <Field label="Data dostawy" value={formatDatePl(order.deliveryDate)} />
+                    <Field
+                      label="Data dostawy"
+                      value={formatDatePl(order.deliveryDate)}
+                    />
                   )}
                 </div>
 
                 {order.deliveryNotes && (
                   <div className="p-3 bg-neutral-50 dark:bg-neutral-800/50 rounded-lg border border-neutral-200 dark:border-neutral-700">
-                    <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1">Uwagi</p>
-                    <p className="text-sm text-neutral-700 dark:text-neutral-300">{order.deliveryNotes}</p>
+                    <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1">
+                      Uwagi
+                    </p>
+                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                      {order.deliveryNotes}
+                    </p>
                   </div>
                 )}
               </div>
             </SectionCard>
 
-            {/* Dania */}
             {items.length > 0 && (
               <SectionCard
                 icon={Utensils}
@@ -365,10 +456,18 @@ export default function CateringOrderDetailPage() {
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="bg-neutral-50 dark:bg-neutral-800/50 border-y border-neutral-200 dark:border-neutral-700">
-                        <th className="text-left px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Danie</th>
-                        <th className="text-center px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Ilość</th>
-                        <th className="text-right px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Cena jedn.</th>
-                        <th className="text-right px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Razem</th>
+                        <th className="text-left px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Danie
+                        </th>
+                        <th className="text-center px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Ilość
+                        </th>
+                        <th className="text-right px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Cena jedn.
+                        </th>
+                        <th className="text-right px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Razem
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
@@ -376,7 +475,9 @@ export default function CateringOrderDetailPage() {
                         <tr
                           key={item.id}
                           className={`border-b border-neutral-100 dark:border-neutral-800 last:border-0 ${
-                            i % 2 === 1 ? 'bg-neutral-50/50 dark:bg-neutral-800/20' : 'bg-white dark:bg-transparent'
+                            i % 2 === 1
+                              ? 'bg-neutral-50/50 dark:bg-neutral-800/20'
+                              : 'bg-white dark:bg-transparent'
                           }`}
                         >
                           <td className="px-5 py-3">
@@ -384,7 +485,9 @@ export default function CateringOrderDetailPage() {
                               {item.dishNameSnapshot ?? '—'}
                             </span>
                             {item.note && (
-                              <span className="block text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">{item.note}</span>
+                              <span className="block text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                                {item.note}
+                              </span>
                             )}
                           </td>
                           <td className="text-center px-4 py-3 text-neutral-600 dark:text-neutral-400 font-mono">
@@ -401,7 +504,10 @@ export default function CateringOrderDetailPage() {
                     </tbody>
                     <tfoot>
                       <tr className="bg-green-50 dark:bg-green-900/10 border-t-2 border-green-200 dark:border-green-800">
-                        <td colSpan={3} className="px-5 py-3 text-right text-sm font-semibold text-green-700 dark:text-green-300">
+                        <td
+                          colSpan={3}
+                          className="px-5 py-3 text-right text-sm font-semibold text-green-700 dark:text-green-300"
+                        >
                           Razem za dania
                         </td>
                         <td className="text-right px-5 py-3 font-bold text-green-700 dark:text-green-300">
@@ -414,7 +520,6 @@ export default function CateringOrderDetailPage() {
               </SectionCard>
             )}
 
-            {/* Extras */}
             {extras.length > 0 && (
               <SectionCard
                 icon={Star}
@@ -428,10 +533,18 @@ export default function CateringOrderDetailPage() {
                   <table className="w-full text-sm">
                     <thead>
                       <tr className="bg-neutral-50 dark:bg-neutral-800/50 border-y border-neutral-200 dark:border-neutral-700">
-                        <th className="text-left px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Usługa</th>
-                        <th className="text-center px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Ilość</th>
-                        <th className="text-right px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Cena jedn.</th>
-                        <th className="text-right px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">Razem</th>
+                        <th className="text-left px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Usługa
+                        </th>
+                        <th className="text-center px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Ilość
+                        </th>
+                        <th className="text-right px-4 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Cena jedn.
+                        </th>
+                        <th className="text-right px-5 py-3 text-xs font-semibold text-neutral-500 uppercase tracking-wide">
+                          Razem
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
@@ -439,13 +552,19 @@ export default function CateringOrderDetailPage() {
                         <tr
                           key={extra.id}
                           className={`border-b border-neutral-100 dark:border-neutral-800 last:border-0 ${
-                            i % 2 === 1 ? 'bg-neutral-50/50 dark:bg-neutral-800/20' : 'bg-white dark:bg-transparent'
+                            i % 2 === 1
+                              ? 'bg-neutral-50/50 dark:bg-neutral-800/20'
+                              : 'bg-white dark:bg-transparent'
                           }`}
                         >
                           <td className="px-5 py-3">
-                            <span className="font-medium text-neutral-900 dark:text-neutral-100">{extra.name}</span>
+                            <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                              {extra.name}
+                            </span>
                             {extra.description && (
-                              <span className="block text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">{extra.description}</span>
+                              <span className="block text-xs text-neutral-500 dark:text-neutral-400 mt-0.5">
+                                {extra.description}
+                              </span>
                             )}
                           </td>
                           <td className="text-center px-4 py-3 text-neutral-600 dark:text-neutral-400 font-mono">
@@ -462,7 +581,10 @@ export default function CateringOrderDetailPage() {
                     </tbody>
                     <tfoot>
                       <tr className="bg-amber-50 dark:bg-amber-900/10 border-t-2 border-amber-200 dark:border-amber-800">
-                        <td colSpan={3} className="px-5 py-3 text-right text-sm font-semibold text-amber-700 dark:text-amber-300">
+                        <td
+                          colSpan={3}
+                          className="px-5 py-3 text-right text-sm font-semibold text-amber-700 dark:text-amber-300"
+                        >
                           Razem za usługi
                         </td>
                         <td className="text-right px-5 py-3 font-bold text-amber-700 dark:text-amber-300">
@@ -476,17 +598,24 @@ export default function CateringOrderDetailPage() {
             )}
           </div>
 
-          {/* RIGHT COLUMN — 1/3 */}
+          {/* RIGHT COLUMN */}
           <div className="space-y-6">
 
             {/* Klient */}
             <SectionCard
               icon={isCompany ? Building2 : User}
-              iconBg={isCompany ? 'bg-violet-100 dark:bg-violet-900/30' : 'bg-indigo-100 dark:bg-indigo-900/30'}
-              iconColor={isCompany ? 'text-violet-600 dark:text-violet-400' : 'text-indigo-600 dark:text-indigo-400'}
+              iconBg={
+                isCompany
+                  ? 'bg-violet-100 dark:bg-violet-900/30'
+                  : 'bg-indigo-100 dark:bg-indigo-900/30'
+              }
+              iconColor={
+                isCompany
+                  ? 'text-violet-600 dark:text-violet-400'
+                  : 'text-indigo-600 dark:text-indigo-400'
+              }
               title="Klient"
             >
-              {/* Avatar row */}
               <div className="flex items-center gap-3 mb-4">
                 <div
                   className={`w-12 h-12 rounded-full flex items-center justify-center text-white font-bold text-lg shrink-0 ${
@@ -498,7 +627,9 @@ export default function CateringOrderDetailPage() {
                   {initials}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="font-semibold text-neutral-900 dark:text-neutral-100 truncate">{clientName}</p>
+                  <p className="font-semibold text-neutral-900 dark:text-neutral-100 truncate">
+                    {clientName}
+                  </p>
                   {isCompany && (
                     <span className="inline-flex items-center gap-1 text-xs bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 px-2 py-0.5 rounded-full">
                       <Building2 className="w-2.5 h-2.5" /> Firma
@@ -522,7 +653,9 @@ export default function CateringOrderDetailPage() {
                 )}
               </div>
 
-              {(order.contactName || order.contactPhone || order.contactEmail) && (
+              {(order.contactName ||
+                order.contactPhone ||
+                order.contactEmail) && (
                 <div className="mt-4 pt-4 border-t border-neutral-100 dark:border-neutral-800">
                   <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-3">
                     Kontakt do zamówienia
@@ -531,7 +664,9 @@ export default function CateringOrderDetailPage() {
                     {order.contactName && (
                       <div className="flex items-center gap-2.5 text-sm">
                         <User className="w-4 h-4 shrink-0 text-neutral-400" />
-                        <span className="font-medium text-neutral-900 dark:text-neutral-100">{order.contactName}</span>
+                        <span className="font-medium text-neutral-900 dark:text-neutral-100">
+                          {order.contactName}
+                        </span>
                       </div>
                     )}
                     {order.contactPhone && (
@@ -551,7 +686,9 @@ export default function CateringOrderDetailPage() {
               )}
 
               <button
-                onClick={() => router.push(`/dashboard/clients/${order.client.id}`)}
+                onClick={() =>
+                  router.push(`/dashboard/clients/${order.client.id}`)
+                }
                 className="mt-4 w-full flex items-center justify-center gap-1.5 text-xs font-medium text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 transition-colors"
               >
                 Profil klienta <ChevronRight className="w-3.5 h-3.5" />
@@ -564,7 +701,26 @@ export default function CateringOrderDetailPage() {
               iconBg="bg-emerald-100 dark:bg-emerald-900/30"
               iconColor="text-emerald-600 dark:text-emerald-400"
               title="Rozliczenie"
+              badge={
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-8 px-3 text-xs gap-1.5 text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
+                  onClick={() => setDiscountDialogOpen(true)}
+                >
+                  {hasDiscount ? (
+                    <>
+                      <Pencil className="w-3.5 h-3.5" /> Edytuj rabat
+                    </>
+                  ) : (
+                    <>
+                      <Plus className="w-3.5 h-3.5" /> Dodaj rabat
+                    </>
+                  )}
+                </Button>
+              }
             >
+              {/* Podsumowanie kwot */}
               <div className="space-y-2.5">
                 {Number(order.subtotal) > 0 && (
                   <div className="flex items-center justify-between text-sm">
@@ -579,26 +735,38 @@ export default function CateringOrderDetailPage() {
                     <span className="flex items-center gap-2 text-neutral-500 dark:text-neutral-400">
                       <Star className="w-3.5 h-3.5" /> Usługi dodatkowe
                     </span>
-                    <span className="font-medium">{formatPrice(order.extrasTotalPrice)}</span>
+                    <span className="font-medium">
+                      {formatPrice(order.extrasTotalPrice)}
+                    </span>
                   </div>
                 )}
-                {order.discountAmount && Number(order.discountAmount) > 0 && (
+                {hasDiscount && Number(order.discountAmount) > 0 && (
                   <div className="flex items-center justify-between text-sm text-emerald-600 dark:text-emerald-400">
                     <span>
                       Rabat
-                      {order.discountType === 'PERCENTAGE' && order.discountValue
+                      {order.discountType === 'PERCENTAGE' &&
+                      order.discountValue
                         ? ` (${order.discountValue}%)`
                         : ''}
+                      {order.discountReason && (
+                        <span className="block text-xs text-neutral-400 font-normal">
+                          {order.discountReason}
+                        </span>
+                      )}
                     </span>
-                    <span className="font-medium">−{formatPrice(order.discountAmount)}</span>
+                    <span className="font-medium">
+                      −{formatPrice(order.discountAmount)}
+                    </span>
                   </div>
                 )}
               </div>
 
-              {/* Total */}
+              {/* Łącznie */}
               <div className="mt-4 pt-4 border-t-2 border-dashed border-neutral-200 dark:border-neutral-700">
                 <div className="flex items-center justify-between">
-                  <span className="text-base font-bold text-neutral-900 dark:text-neutral-100">Łącznie</span>
+                  <span className="text-base font-bold text-neutral-900 dark:text-neutral-100">
+                    Łącznie
+                  </span>
                   <span className="text-xl font-extrabold text-neutral-900 dark:text-neutral-100">
                     {formatPrice(order.totalPrice)}
                   </span>
@@ -610,39 +778,89 @@ export default function CateringOrderDetailPage() {
                 )}
               </div>
 
-              {/* Depozyty */}
-              {deposits.length > 0 && (
-                <div className="mt-4 pt-4 border-t border-neutral-100 dark:border-neutral-800 space-y-2">
-                  <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider mb-3">Zaliczki</p>
-                  {deposits.map(d => {
-                    const paid = d.paid || d.status === 'PAID';
-                    return (
-                      <div key={d.id} className="flex items-center gap-3">
-                        <div className="shrink-0">
-                          {paid
-                            ? <CheckCircle2 className="w-4 h-4 text-emerald-500" />
-                            : <Circle className="w-4 h-4 text-neutral-300 dark:text-neutral-600" />}
-                        </div>
-                        <div className="flex-1 min-w-0">
-                          <p className={`text-xs font-medium truncate ${
-                            paid ? 'text-emerald-700 dark:text-emerald-300' : 'text-neutral-600 dark:text-neutral-400'
-                          }`}>
-                            {d.title ?? 'Zaliczka'}
-                          </p>
-                          {d.dueDate && (
-                            <p className="text-xs text-neutral-400 dark:text-neutral-500">{formatDatePl(d.dueDate)}</p>
+              {/* Zaliczki */}
+              <div className="mt-4 pt-4 border-t border-neutral-100 dark:border-neutral-800">
+                <div className="flex items-center justify-between mb-3">
+                  <p className="text-xs font-medium text-neutral-400 dark:text-neutral-500 uppercase tracking-wider">
+                    Zaliczki
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2.5 text-xs gap-1 text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+                    onClick={() => setDepositDialogOpen(true)}
+                  >
+                    <Plus className="w-3 h-3" /> Dodaj
+                  </Button>
+                </div>
+
+                {deposits.length === 0 ? (
+                  <p className="text-xs text-neutral-400 dark:text-neutral-500 text-center py-3">
+                    Brak zaliczek
+                  </p>
+                ) : (
+                  <div className="space-y-2">
+                    {deposits.map((d) => {
+                      const paid = d.paid || d.status === 'PAID';
+                      return (
+                        <div
+                          key={d.id}
+                          className="flex items-center gap-3"
+                        >
+                          <div className="shrink-0">
+                            {paid ? (
+                              <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+                            ) : (
+                              <Circle className="w-4 h-4 text-neutral-300 dark:text-neutral-600" />
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <p
+                              className={`text-xs font-medium truncate ${
+                                paid
+                                  ? 'text-emerald-700 dark:text-emerald-300'
+                                  : 'text-neutral-600 dark:text-neutral-400'
+                              }`}
+                            >
+                              {d.title ?? 'Zaliczka'}
+                            </p>
+                            {d.dueDate && (
+                              <p className="text-xs text-neutral-400 dark:text-neutral-500">
+                                {formatDatePl(d.dueDate)}
+                              </p>
+                            )}
+                          </div>
+                          <span
+                            className={`text-xs font-bold shrink-0 ${
+                              paid
+                                ? 'text-emerald-600 dark:text-emerald-400'
+                                : 'text-neutral-600 dark:text-neutral-400'
+                            }`}
+                          >
+                            {formatPrice(d.amount)}
+                          </span>
+                          {!paid && (
+                            <Button
+                              size="sm"
+                              variant="ghost"
+                              className="h-6 px-2 text-xs shrink-0 text-emerald-600 hover:text-emerald-700 hover:bg-emerald-50 dark:hover:bg-emerald-900/20"
+                              onClick={() =>
+                                setPayingDeposit({
+                                  id: d.id,
+                                  amount: d.amount,
+                                  title: d.title,
+                                })
+                              }
+                            >
+                              Opłać
+                            </Button>
                           )}
                         </div>
-                        <span className={`text-xs font-bold shrink-0 ${
-                          paid ? 'text-emerald-600 dark:text-emerald-400' : 'text-neutral-600 dark:text-neutral-400'
-                        }`}>
-                          {formatPrice(d.amount)}
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             </SectionCard>
 
             {/* Uwagi */}
@@ -656,21 +874,35 @@ export default function CateringOrderDetailPage() {
                 <div className="space-y-4">
                   {order.notes && (
                     <div>
-                      <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1.5">Uwagi</p>
-                      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">{order.notes}</p>
+                      <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1.5">
+                        Uwagi
+                      </p>
+                      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">
+                        {order.notes}
+                      </p>
                     </div>
                   )}
                   {order.specialRequirements && (
-                    <div className={order.notes ? 'pt-3 border-t border-neutral-100 dark:border-neutral-800' : ''}>
-                      <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1.5">Specjalne wymagania</p>
-                      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">{order.specialRequirements}</p>
+                    <div
+                      className={
+                        order.notes
+                          ? 'pt-3 border-t border-neutral-100 dark:border-neutral-800'
+                          : ''
+                      }
+                    >
+                      <p className="text-xs font-medium text-neutral-400 uppercase tracking-wider mb-1.5">
+                        Specjalne wymagania
+                      </p>
+                      <p className="text-sm text-neutral-700 dark:text-neutral-300 leading-relaxed">
+                        {order.specialRequirements}
+                      </p>
                     </div>
                   )}
                 </div>
               </SectionCard>
             )}
 
-            {/* Historia zmian — SectionCard z ikoną History */}
+            {/* Historia */}
             <SectionCard
               icon={History}
               iconBg="bg-slate-100 dark:bg-slate-800"
@@ -679,17 +911,45 @@ export default function CateringOrderDetailPage() {
             >
               <OrderTimeline orderId={id} />
             </SectionCard>
-
           </div>
         </div>
       </div>
 
+      {/* ═══ DIALOGI ═══ */}
       <ChangeStatusDialog
         orderId={id}
         currentStatus={order.status}
         open={statusDialogOpen}
         onClose={() => setStatusDialogOpen(false)}
       />
+
+      <DiscountDialog
+        orderId={id}
+        current={{
+          discountType: order.discountType,
+          discountValue: order.discountValue,
+          discountReason: order.discountReason,
+        }}
+        open={discountDialogOpen}
+        onClose={() => setDiscountDialogOpen(false)}
+      />
+
+      <AddDepositDialog
+        orderId={id}
+        open={depositDialogOpen}
+        onClose={() => setDepositDialogOpen(false)}
+      />
+
+      {payingDeposit && (
+        <MarkDepositPaidDialog
+          orderId={id}
+          depositId={payingDeposit.id}
+          depositTitle={payingDeposit.title}
+          depositAmount={payingDeposit.amount}
+          open={true}
+          onClose={() => setPayingDeposit(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/frontend/app/dashboard/catering/orders/components/AddDepositDialog.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/components/AddDepositDialog.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { useCreateCateringDeposit } from '@/hooks/use-catering-orders';
+import { Loader2 } from 'lucide-react';
+
+interface Props {
+  orderId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function AddDepositDialog({ orderId, open, onClose }: Props) {
+  const [title, setTitle] = useState('');
+  const [amount, setAmount] = useState('');
+  const [dueDate, setDueDate] = useState('');
+  const [description, setDescription] = useState('');
+
+  const create = useCreateCateringDeposit(orderId);
+
+  const handleSubmit = async () => {
+    const num = parseFloat(amount);
+    if (isNaN(num) || num <= 0 || !dueDate) return;
+    await create.mutateAsync({
+      amount: num,
+      dueDate,
+      title: title || null,
+      description: description || null,
+    });
+    setTitle('');
+    setAmount('');
+    setDueDate('');
+    setDescription('');
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Dodaj zaliczkę</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label>
+              Tytuł{' '}
+              <span className="text-neutral-400 font-normal">(opcjonalnie)</span>
+            </Label>
+            <Input
+              placeholder="np. Zaliczka 30%, Zadatek"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>
+              Kwota (PLN) <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              type="number"
+              min={0}
+              step={0.01}
+              placeholder="np. 500.00"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>
+              Termin płatności <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              type="date"
+              value={dueDate}
+              onChange={(e) => setDueDate(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>
+              Opis{' '}
+              <span className="text-neutral-400 font-normal">(opcjonalnie)</span>
+            </Label>
+            <Textarea
+              placeholder="Dodatkowe informacje..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={create.isPending}
+          >
+            Anuluj
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={create.isPending || !amount || !dueDate}
+          >
+            {create.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Dodaj zaliczkę
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/app/dashboard/catering/orders/components/DiscountDialog.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/components/DiscountDialog.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useUpdateCateringOrder } from '@/hooks/use-catering-orders';
+import type { CateringDiscountType } from '@/types/catering-order.types';
+import { Loader2, Percent, Banknote } from 'lucide-react';
+
+interface Props {
+  orderId: string;
+  current?: {
+    discountType?: CateringDiscountType | null;
+    discountValue?: number | null;
+    discountReason?: string | null;
+  };
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DiscountDialog({ orderId, current, open, onClose }: Props) {
+  const [type, setType] = useState<CateringDiscountType>(
+    current?.discountType ?? 'PERCENTAGE',
+  );
+  const [value, setValue] = useState(String(current?.discountValue ?? ''));
+  const [reason, setReason] = useState(current?.discountReason ?? '');
+
+  const update = useUpdateCateringOrder(orderId);
+
+  const handleSubmit = async () => {
+    const numValue = parseFloat(value);
+    if (isNaN(numValue) || numValue <= 0) return;
+    await update.mutateAsync({
+      discountType: type,
+      discountValue: numValue,
+      discountReason: reason || null,
+    });
+    onClose();
+  };
+
+  const handleRemove = async () => {
+    await update.mutateAsync({
+      discountType: null,
+      discountValue: null,
+      discountReason: null,
+    });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {current?.discountType ? 'Edytuj rabat' : 'Dodaj rabat'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label>Typ rabatu</Label>
+            <Select
+              value={type}
+              onValueChange={(v) => setType(v as CateringDiscountType)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="PERCENTAGE">
+                  <span className="flex items-center gap-2">
+                    <Percent className="w-4 h-4" /> Procentowy
+                  </span>
+                </SelectItem>
+                <SelectItem value="AMOUNT">
+                  <span className="flex items-center gap-2">
+                    <Banknote className="w-4 h-4" /> Kwotowy (PLN)
+                  </span>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Wartość {type === 'PERCENTAGE' ? '(%)' : '(PLN)'}</Label>
+            <Input
+              type="number"
+              min={0}
+              max={type === 'PERCENTAGE' ? 100 : undefined}
+              step={type === 'PERCENTAGE' ? 1 : 0.01}
+              placeholder={type === 'PERCENTAGE' ? 'np. 10' : 'np. 150.00'}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label>
+              Powód rabatu{' '}
+              <span className="text-neutral-400 font-normal">(opcjonalnie)</span>
+            </Label>
+            <Textarea
+              placeholder="np. Stały klient, upust specjalny..."
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          {current?.discountType && (
+            <Button
+              variant="ghost"
+              className="text-destructive hover:text-destructive mr-auto"
+              onClick={handleRemove}
+              disabled={update.isPending}
+            >
+              Usuń rabat
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={update.isPending}
+          >
+            Anuluj
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={update.isPending || !value}
+          >
+            {update.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Zapisz
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/app/dashboard/catering/orders/components/MarkDepositPaidDialog.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/components/MarkDepositPaidDialog.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useMarkDepositPaid } from '@/hooks/use-catering-orders';
+import type { MarkDepositPaidInput } from '@/types/catering-order.types';
+import {
+  Loader2,
+  Banknote,
+  CreditCard,
+  Smartphone,
+  ArrowLeftRight,
+} from 'lucide-react';
+
+const PAYMENT_METHODS: {
+  value: NonNullable<MarkDepositPaidInput['paymentMethod']>;
+  label: string;
+  icon: React.ElementType;
+}[] = [
+  { value: 'CASH',     label: 'Gotówka', icon: Banknote },
+  { value: 'TRANSFER', label: 'Przelew', icon: ArrowLeftRight },
+  { value: 'BLIK',     label: 'BLIK',    icon: Smartphone },
+  { value: 'CARD',     label: 'Karta',   icon: CreditCard },
+];
+
+function formatPrice(v: number) {
+  return new Intl.NumberFormat('pl-PL', {
+    style: 'currency',
+    currency: 'PLN',
+  }).format(v);
+}
+
+interface Props {
+  orderId: string;
+  depositId: string;
+  depositTitle?: string | null;
+  depositAmount: number;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function MarkDepositPaidDialog({
+  orderId,
+  depositId,
+  depositTitle,
+  depositAmount,
+  open,
+  onClose,
+}: Props) {
+  const [paymentMethod, setPaymentMethod] =
+    useState<MarkDepositPaidInput['paymentMethod']>('TRANSFER');
+
+  const markPaid = useMarkDepositPaid(orderId, depositId);
+
+  const handleSubmit = async () => {
+    await markPaid.mutateAsync({ paymentMethod });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Oznacz zaliczkę jako opłaconą</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="p-4 bg-emerald-50 dark:bg-emerald-900/20 rounded-xl border border-emerald-200 dark:border-emerald-800 text-center">
+            <p className="text-xs text-emerald-600 dark:text-emerald-400 font-medium mb-1">
+              {depositTitle ?? 'Zaliczka'}
+            </p>
+            <p className="text-2xl font-extrabold text-emerald-700 dark:text-emerald-300">
+              {formatPrice(depositAmount)}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Metoda płatności</Label>
+            <Select
+              value={paymentMethod}
+              onValueChange={(v) =>
+                setPaymentMethod(v as MarkDepositPaidInput['paymentMethod'])
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PAYMENT_METHODS.map(({ value, label, icon: Icon }) => (
+                  <SelectItem key={value} value={value}>
+                    <span className="flex items-center gap-2">
+                      <Icon className="w-4 h-4" /> {label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={markPaid.isPending}
+          >
+            Anuluj
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={markPaid.isPending}
+            className="bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            {markPaid.isPending && (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            )}
+            Potwierdź opłatę
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Closes #150 (częściowo — Faza 2 frontend do dopracowania)

## Co robi ten PR

Dodaje pełny UI do zarządzania **rabatami** i **depozytyami** bezpośrednio ze strony szczegółów zamówienia cateringowego. Backend dla obu funkcji był już gotowy (migracja `20260304000000_catering_phase2_orders`), brakowało tylko widoków.

---

## Nowe komponenty

### `DiscountDialog.tsx`
- Dodaj / edytuj / usuń rabat
- Typy: `PERCENTAGE` (%) lub `AMOUNT` (PLN)
- Pole powodu rabatu (opcjonalne)
- Przycisk „Usuń rabat” widoczny tylko gdy rabat już istnieje
- Wywołuje `useUpdateCateringOrder`

### `AddDepositDialog.tsx`
- Nowa zaliczka: tytuł, kwota, termin płatności, opis
- Walidacja: kwota > 0 i termin są wymagane
- Wywołuje `useCreateCateringDeposit`

### `MarkDepositPaidDialog.tsx`
- Oznacz zaliczkę jako opłaconą
- Wybierz metodę płatności: Gotówka / Przelew / BLIK / Karta
- Zielone potwierdzenie z kwotą i tytułem zaliczki
- Wywołuje `useMarkDepositPaid`

---

## Zmiany w `[id]/page.tsx`

- Dodane importy: `Plus`, `Pencil` (Lucide), 3 nowe dialogi
- Nowe stany: `discountDialogOpen`, `depositDialogOpen`, `payingDeposit`
- **SectionCard Rozliczenie** — badge z przyciskiem _„Dodaj rabat” / „Edytuj rabat”_
- **Sekcja Zaliczki** — zawsze widoczna (wcześniej tylko gdy `deposits.length > 0`)
  - Przycisk _„Dodaj”_ w nagłówku sekcji
  - Per nieopłacona zaliczka: przycisk _„Opłać”_
  - Empty state „Brak zaliczek” gdy lista pusta
- Rabat w rozliczeniu wyświetla teraz również `discountReason` pod kwotą

---

## Test checklist

- [ ] Dodaj rabat procentowy (np. 10%) → kwota zmniejsza się w łącznej cenie
- [ ] Edytuj rabat → zmień typ na kwotowy
- [ ] Usuń rabat → cena wraca do oryginalnej
- [ ] Dodaj zaliczkę z tytułem i terminem → pojawia się na liście
- [ ] Oznacz zaliczkę jako opłaconą (BLIK) → ikońka zmienia się na zieloną