### PR TITLE
fix: historia zmian aktualizuje się w czasie rzeczywistym

### DIFF
--- a/apps/frontend/hooks/use-catering-orders.ts
+++ b/apps/frontend/hooks/use-catering-orders.ts
@@ -97,6 +97,7 @@ export function useUpdateCateringOrder(id: string) {
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: orderKey(id) });
+      await qc.invalidateQueries({ queryKey: historyKey(id) });
       await qc.invalidateQueries({ queryKey: ['catering-orders'] });
     },
   });
@@ -138,6 +139,7 @@ export function useCreateCateringDeposit(orderId: string) {
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: orderKey(orderId) });
+      await qc.invalidateQueries({ queryKey: historyKey(orderId) });
     },
   });
 }
@@ -154,6 +156,7 @@ export function useMarkDepositPaid(orderId: string, depositId: string) {
     },
     onSuccess: async () => {
       await qc.invalidateQueries({ queryKey: orderKey(orderId) });
+      await qc.invalidateQueries({ queryKey: historyKey(orderId) });
     },
   });
 }


### PR DESCRIPTION
## Problem

Po dodaniu zaliczki, opłaceniu zaliczki lub zmianie rabatu historia zmian
odpowieźda się dopiero po ręcznym odświeżeniu strony.

## Przyczyna

Trzy mutacje nie wywoływały `invalidateQueries` dla `historyKey`:

| Mutacja | Przed | Po |
|---|---|---|
| `useUpdateCateringOrder` | `orderKey` + `ordersKey` | + `historyKey` |
| `useCreateCateringDeposit` | `orderKey` | + `historyKey` |
| `useMarkDepositPaid` | `orderKey` | + `historyKey` |

`useChangeCateringOrderStatus` już miał invalidację historii — bez zmian.

## Efekt

Po każdej mutacji TanStack Query automatycznie odświeża `OrderTimeline`
bez potrzeby ręcznego odświeżania strony.