### PR TITLE
fix(catering): napraw pobieranie PDF zamówienia

### DIFF
--- a/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
@@ -306,7 +306,7 @@ export default function CateringOrderDetailPage() {
 
   const handleDownloadPDF = async () => {
     try {
-      const response = await apiClient.get(`/api/catering/orders/${id}/pdf/order`, {
+      const response = await apiClient.get(`/catering/orders/${id}/pdf/order`, {
         responseType: 'blob',
       });
       


### PR DESCRIPTION
## Summary
- Usunięto podwójny prefix `/api/api/` w URL pobierania PDF zamówienia catering
- `apiClient` już ma `/api` w baseURL, więc ścieżka tworzyła `/api/api/catering/orders/.../pdf/order` zamiast `/api/catering/orders/.../pdf/order`

## Test plan
- [ ] Kliknij "Pobierz PDF" w szczegółach zamówienia catering
- [ ] PDF powinien się pobrać bez błędu 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)