### PR TITLE
feat(catering): Faza 3 — ActivityLog, załączniki, ServiceItem

### DIFF
--- a/apps/backend/prisma/migrations/20260312_catering_phase3_integrations/migration.sql
+++ b/apps/backend/prisma/migrations/20260312_catering_phase3_integrations/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable: Add optional ServiceItem reference to CateringOrderExtra
+ALTER TABLE "CateringOrderExtra" ADD COLUMN "serviceItemId" UUID;
+
+-- AddForeignKey
+ALTER TABLE "CateringOrderExtra" ADD CONSTRAINT "CateringOrderExtra_serviceItemId_fkey" FOREIGN KEY ("serviceItemId") REFERENCES "ServiceItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "CateringOrderExtra_serviceItemId_idx" ON "CateringOrderExtra"("serviceItemId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -791,6 +791,7 @@ model ServiceItem {
 
   category      ServiceCategory @relation(fields: [categoryId], references: [id], onDelete: Cascade)
   reservationExtras ReservationExtra[]
+  cateringExtras    CateringOrderExtra[]
 
   @@index([categoryId])
   @@index([isActive])
@@ -1102,21 +1103,24 @@ model CateringOrderItem {
 }
 
 model CateringOrderExtra {
-  id          String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  orderId     String        @db.Uuid
+  id            String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  orderId       String        @db.Uuid
+  serviceItemId String?       @db.Uuid
 
-  name        String        @db.VarChar(255)
-  description String?       @db.Text
-  quantity    Int           @default(1) @db.SmallInt
-  unitPrice   Decimal       @db.Decimal(10, 2)
-  totalPrice  Decimal       @db.Decimal(10, 2)
+  name          String        @db.VarChar(255)
+  description   String?       @db.Text
+  quantity      Int           @default(1) @db.SmallInt
+  unitPrice     Decimal       @db.Decimal(10, 2)
+  totalPrice    Decimal       @db.Decimal(10, 2)
 
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
 
-  order       CateringOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  order         CateringOrder @relation(fields: [orderId], references: [id], onDelete: Cascade)
+  serviceItem   ServiceItem?  @relation(fields: [serviceItemId], references: [id], onDelete: SetNull)
 
   @@index([orderId])
+  @@index([serviceItemId])
 }
 
 model CateringOrderHistory {

--- a/apps/backend/src/constants/attachmentCategories.ts
+++ b/apps/backend/src/constants/attachmentCategories.ts
@@ -3,7 +3,7 @@
  * Shared constants for frontend and backend validation
  */
 
-export const ENTITY_TYPES = ['CLIENT', 'RESERVATION', 'DEPOSIT'] as const;
+export const ENTITY_TYPES = ['CLIENT', 'RESERVATION', 'DEPOSIT', 'CATERING_ORDER'] as const;
 export type EntityType = typeof ENTITY_TYPES[number];
 
 export interface AttachmentCategoryDef {
@@ -31,6 +31,15 @@ export const ATTACHMENT_CATEGORIES: Record<EntityType, AttachmentCategoryDef[]> 
     { value: 'INVOICE', label: 'Faktura zaliczkowa', description: 'Faktura VAT za wpłaconą zaliczkę' },
     { value: 'REFUND_PROOF', label: 'Potwierdzenie zwrotu', description: 'Dokument potwierdzający zwrot' },
     { value: 'OTHER', label: 'Inne', description: 'Inne dokumenty zaliczki' },
+  ],
+  CATERING_ORDER: [
+    { value: 'RODO', label: 'Zgoda RODO', description: 'Podpisana zgoda RODO — zostanie automatycznie przypisana do klienta' },
+    { value: 'CONTRACT', label: 'Umowa catering', description: 'Podpisana umowa na usługę cateringową' },
+    { value: 'INVOICE', label: 'Faktura', description: 'Faktura VAT za zamówienie cateringowe' },
+    { value: 'MENU', label: 'Menu / karta dań', description: 'Uzgodnione menu, karta dań klienta' },
+    { value: 'DIETARY', label: 'Wymagania dietetyczne', description: 'Informacje o alergiach, dietach, preferencjach' },
+    { value: 'CORRESPONDENCE', label: 'Korespondencja', description: 'Ustalenia mailowe, SMS, screenshots rozmów' },
+    { value: 'OTHER', label: 'Inne', description: 'Inne dokumenty zamówienia cateringowego' },
   ],
 };
 
@@ -88,4 +97,5 @@ export const STORAGE_DIRS: Record<EntityType, string> = {
   CLIENT: 'clients',
   RESERVATION: 'reservations',
   DEPOSIT: 'deposits',
+  CATERING_ORDER: 'catering_orders',
 };

--- a/apps/backend/src/services/attachment.service.ts
+++ b/apps/backend/src/services/attachment.service.ts
@@ -130,6 +130,14 @@ class AttachmentService {
         return deposit?.reservation?.clientId || null;
       }
 
+      if (entityType === 'CATERING_ORDER') {
+        const order = await prisma.cateringOrder.findUnique({
+          where: { id: entityId },
+          select: { clientId: true },
+        });
+        return order?.clientId || null;
+      }
+
       return null;
     } catch (error) {
       logger.error(`Failed to resolve clientId for ${entityType}/${entityId}:`, error);
@@ -684,6 +692,9 @@ class AttachmentService {
         break;
       case 'DEPOSIT':
         exists = !!(await prisma.deposit.findUnique({ where: { id: entityId }, select: { id: true } }));
+        break;
+      case 'CATERING_ORDER':
+        exists = !!(await prisma.cateringOrder.findUnique({ where: { id: entityId }, select: { id: true } }));
         break;
       default:
         throw AppError.badRequest(`Nieobsługiwany entityType: ${entityType}`);

--- a/apps/backend/src/services/catering-order.service.ts
+++ b/apps/backend/src/services/catering-order.service.ts
@@ -5,6 +5,7 @@ import {
   CateringDiscountType,
   Prisma,
 } from '@prisma/client';
+import { logChange } from '../utils/audit-logger';
 
 // ─── Auto-numeracja: CAT-YYYY-XXXXX ────────────────────────────────────────
 
@@ -31,6 +32,7 @@ export interface CreateOrderExtraInput {
   description?: string | null;
   quantity: number;
   unitPrice: number;
+  serviceItemId?: string | null;
 }
 
 export interface CreateCateringOrderInput {
@@ -181,7 +183,10 @@ const orderInclude = {
     include: { dish: { select: { id: true, name: true } } },
     orderBy: { createdAt: 'asc' as const },
   },
-  extras: { orderBy: { createdAt: 'asc' as const } },
+  extras: {
+    include: { serviceItem: { select: { id: true, name: true, icon: true } } },
+    orderBy: { createdAt: 'asc' as const },
+  },
   deposits: { orderBy: { dueDate: 'asc' as const } },
 } satisfies Prisma.CateringOrderInclude;
 
@@ -196,7 +201,7 @@ export async function createOrder(
   const resolvedItems = await resolveDishNames(items);
   const totals = computeTotals(items, extras, input.discountType, input.discountValue);
 
-  return prisma.cateringOrder.create({
+  const order = await prisma.cateringOrder.create({
     data: {
       orderNumber,
       clientId: input.clientId,
@@ -244,6 +249,7 @@ export async function createOrder(
           quantity: e.quantity,
           unitPrice: e.unitPrice,
           totalPrice: e.quantity * e.unitPrice,
+          serviceItemId: e.serviceItemId ?? null,
         })),
       },
       history: {
@@ -256,6 +262,27 @@ export async function createOrder(
     },
     include: orderInclude,
   });
+
+  await logChange({
+    userId: input.createdById,
+    action: 'CREATE',
+    entityType: 'CATERING_ORDER',
+    entityId: order.id,
+    details: {
+      description: `Utworzono zamówienie catering: ${order.orderNumber} — ${order.client.firstName} ${order.client.lastName}`,
+      data: {
+        orderNumber: order.orderNumber,
+        clientId: input.clientId,
+        deliveryType: input.deliveryType ?? 'ON_SITE',
+        guestsCount: input.guestsCount ?? 0,
+        itemsCount: items.length,
+        extrasCount: extras.length,
+        totalPrice: totals.totalPrice,
+      },
+    },
+  });
+
+  return order;
 }
 
 export async function getOrderById(
@@ -413,6 +440,7 @@ export async function updateOrder(
           quantity: e.quantity,
           unitPrice: e.unitPrice,
           totalPrice: e.quantity * e.unitPrice,
+          serviceItemId: e.serviceItemId ?? null,
         })),
       };
     }
@@ -487,6 +515,33 @@ export async function updateOrder(
     include: orderInclude,
   });
 
+  const userId = input.changedById ?? existing.createdById;
+
+  if (input.status !== undefined && input.status !== oldStatus) {
+    await logChange({
+      userId,
+      action: 'STATUS_CHANGE',
+      entityType: 'CATERING_ORDER',
+      entityId: id,
+      details: {
+        description: `Zmiana statusu zamówienia ${existing.orderNumber}: ${oldStatus} → ${input.status}`,
+        fieldName: 'status',
+        oldValue: oldStatus,
+        newValue: input.status,
+      },
+    });
+  } else {
+    await logChange({
+      userId,
+      action: 'UPDATE',
+      entityType: 'CATERING_ORDER',
+      entityId: id,
+      details: {
+        description: `Zaktualizowano zamówienie ${existing.orderNumber}`,
+      },
+    });
+  }
+
   if (discountEvent && input.changedById) {
     await prisma.cateringOrderHistory.create({
       data: {
@@ -513,12 +568,23 @@ export async function changeOrderStatus(
   return updateOrder(id, { status, changedById, changeReason: reason });
 }
 
-export async function deleteOrder(id: string): Promise<void> {
+export async function deleteOrder(id: string, deletedById?: string): Promise<void> {
   const order = await prisma.cateringOrder.findUniqueOrThrow({ where: { id } });
   if (order.status !== 'DRAFT' && order.status !== 'CANCELLED') {
     badRequest('Można usunąć tylko zamówienia w statusie DRAFT lub CANCELLED');
   }
   await prisma.cateringOrder.delete({ where: { id } });
+
+  await logChange({
+    userId: deletedById ?? order.createdById,
+    action: 'DELETE',
+    entityType: 'CATERING_ORDER',
+    entityId: id,
+    details: {
+      description: `Usunięto zamówienie catering: ${order.orderNumber}`,
+      data: { orderNumber: order.orderNumber, status: order.status },
+    },
+  });
 }
 
 export async function getOrderHistory(orderId: string) {
@@ -595,6 +661,17 @@ export async function createDeposit(
         changeType: 'DEPOSIT_CREATED',
         fieldName: 'deposit',
         newValue: `${input.title ?? 'Zaliczka'} — ${input.amount} PLN`,
+      },
+    });
+
+    await logChange({
+      userId: changedById,
+      action: 'DEPOSIT_CREATED',
+      entityType: 'CATERING_ORDER',
+      entityId: orderId,
+      details: {
+        description: `Dodano zaliczkę: ${input.title ?? 'Zaliczka'} — ${input.amount} PLN`,
+        data: { depositId: deposit.id, amount: input.amount, dueDate: input.dueDate },
       },
     });
   }
@@ -689,6 +766,17 @@ export async function deleteDeposit(
         newValue: wasPaid ? `wasPaid:true paymentMethod:${deposit.paymentMethod ?? 'N/A'}` : null,
       },
     });
+
+    await logChange({
+      userId: changedById,
+      action: 'DEPOSIT_DELETED',
+      entityType: 'CATERING_ORDER',
+      entityId: orderId,
+      details: {
+        description: `Usunięto zaliczkę: ${deposit.title ?? 'Zaliczka'} — ${deposit.amount} PLN${wasPaid ? ' (była opłacona)' : ''}`,
+        data: { depositId, wasPaid },
+      },
+    });
   }
 }
 
@@ -722,6 +810,17 @@ export async function markDepositPaid(
         changeType: 'DEPOSIT_PAID',
         fieldName: 'deposit',
         newValue: `${deposit.title ?? 'Zaliczka'} — ${deposit.amount} PLN (${paymentMethod ?? 'bez metody'})`,
+      },
+    });
+
+    await logChange({
+      userId: changedById,
+      action: 'DEPOSIT_PAID',
+      entityType: 'CATERING_ORDER',
+      entityId: orderId,
+      details: {
+        description: `Opłacono zaliczkę: ${deposit.title ?? 'Zaliczka'} — ${deposit.amount} PLN`,
+        data: { depositId, amount: Number(deposit.amount), paymentMethod },
       },
     });
   }


### PR DESCRIPTION
## Summary
- **ActivityLog** — audyt wszystkich operacji cateringowych (tworzenie, edycja, usuwanie zamówień, depozyty)
- **Załączniki** — nowy typ `CATERING_ORDER` z kategoriami: Umowa, Faktura, Menu, Wymagania dietetyczne, Korespondencja
- **ServiceItem** — opcjonalne powiązanie extras cateringowych z pozycjami usługowymi (migracja Prisma)

## Test plan
- [ ] Utwórz zamówienie catering → sprawdź ActivityLog
- [ ] Zmień status zamówienia → sprawdź ActivityLog
- [ ] Dodaj/opłać/usuń depozyt → sprawdź ActivityLog
- [ ] Upload załącznika do zamówienia catering (entityType=CATERING_ORDER)
- [ ] Upload RODO przez catering → redirect do klienta
- [ ] Migracja Prisma przechodzi na dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)