### PR TITLE
feat(perf): testy wydajnościowe k6 (#249)

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -1,0 +1,95 @@
+name: Performance Tests (k6)
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: perf-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  k6-smoke:
+    name: k6 Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: rezerwacje
+          POSTGRES_PASSWORD: rezerwacje_password
+          POSTGRES_DB: rezerwacje_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: apps/backend/package-lock.json
+
+      - name: Install k6
+        run: |
+          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt-get update
+          sudo apt-get install -y k6
+
+      - name: Install backend dependencies
+        working-directory: apps/backend
+        run: npm ci
+
+      - name: Setup database
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+        run: |
+          npx prisma generate
+          npx prisma db push --accept-data-loss --force-reset
+
+      - name: Seed test data
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+          NODE_ENV: development
+        run: npm run db:seed
+
+      - name: Start backend server
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+          JWT_SECRET: ${{ secrets.JWT_SECRET_CI || 'perf-ci-jwt-placeholder-not-production' }}
+          NODE_ENV: development
+        run: |
+          npx tsx src/index.ts &
+          npx wait-on http://localhost:3001/api/health --timeout 60000
+
+      - name: Run k6 smoke test
+        run: |
+          k6 run k6/scenarios/smoke.js \
+            --out json=k6-results.json \
+            --summary-export=k6-summary.json
+        env:
+          BASE_URL: http://localhost:3001
+
+      - name: Upload k6 results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-smoke-results
+          path: |
+            k6-results.json
+            k6-summary.json
+          retention-days: 14

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # Development:   make dev
 # Production:    make prod
 # Testing:       make test-unit / test-integration / test-all
+# Performance:   make test-perf / test-perf-load / test-perf-stress
 # Storage:       make migrate-minio / minio-stats / minio-backup
 # DB migrations: make fix-timezone-dry / fix-timezone
 # Cleanup:       make down / test-down
@@ -12,6 +13,7 @@
 .PHONY: dev dev-build dev-down prod prod-build prod-down \
         test-unit test-integration test-security test-frontend test-e2e test-all \
         test-coverage test-frontend-coverage test-down \
+        test-perf test-perf-smoke test-perf-load test-perf-stress test-perf-spike \
         migrate-minio migrate-minio-dry minio-stats minio-ls \
         minio-backup minio-policies \
         fix-timezone-dry fix-timezone \
@@ -99,6 +101,28 @@ test-all: test-unit test-integration test-security test-frontend
 
 test-down:
 	$(COMPOSE_TEST) down -v --remove-orphans
+
+# ============================================
+# Performance Tests — k6 (#249)
+# ============================================
+# Requires k6 installed: https://grafana.com/docs/k6/latest/set-up/install-k6/
+# Backend must be running (make dev or make prod).
+# Override target: BASE_URL=http://localhost:3001 make test-perf-smoke
+# ============================================
+
+test-perf: test-perf-smoke
+
+test-perf-smoke:
+	k6 run k6/scenarios/smoke.js
+
+test-perf-load:
+	k6 run k6/scenarios/load.js
+
+test-perf-stress:
+	k6 run k6/scenarios/stress.js
+
+test-perf-spike:
+	k6 run k6/scenarios/spike.js
 
 # ============================================
 # Storage / MinIO (#146)
@@ -223,6 +247,13 @@ help:
 	@echo "    make test-e2e           E2E tests (Playwright, needs make dev)"
 	@echo "    make test-all           All tests (unit + integration + frontend)"
 	@echo "    make test-down          Stop test containers"
+	@echo ""
+	@echo "  PERFORMANCE (k6, #249):"
+	@echo "    make test-perf          Alias for test-perf-smoke"
+	@echo "    make test-perf-smoke    k6 smoke test (1 VU, all endpoints)"
+	@echo "    make test-perf-load     k6 load test (50 VU, 30s)"
+	@echo "    make test-perf-stress   k6 stress test (ramp to 200 VU)"
+	@echo "    make test-perf-spike    k6 spike test (0->100 VU instant)"
 	@echo ""
 	@echo "  STORAGE / MINIO (#146):"
 	@echo "    make migrate-minio      Migrate files: local -> MinIO"

--- a/k6/config.js
+++ b/k6/config.js
@@ -1,0 +1,58 @@
+// k6/config.js — Shared configuration for k6 performance tests
+// Usage: import { BASE_URL, thresholds, buildUrl } from '../config.js';
+
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:3001';
+
+// --- Thresholds ---
+export const thresholds = {
+  http_req_duration: ['p(95)<500'],   // 95% requests < 500ms
+  http_req_failed: ['rate<0.01'],     // error rate < 1%
+  http_reqs: ['rate>50'],             // throughput > 50 req/s
+};
+
+// --- Stage presets ---
+export const stages = {
+  smoke: [{ duration: '1s', target: 1 }],
+
+  load: [
+    { duration: '10s', target: 50 },  // ramp-up
+    { duration: '30s', target: 50 },  // plateau
+    { duration: '10s', target: 0 },   // ramp-down
+  ],
+
+  stress: [
+    { duration: '10s', target: 50 },
+    { duration: '30s', target: 100 },
+    { duration: '30s', target: 200 },
+    { duration: '10s', target: 0 },
+  ],
+
+  spike: [
+    { duration: '1s', target: 100 },  // instant spike
+    { duration: '10s', target: 100 }, // hold
+    { duration: '5s', target: 0 },    // recovery
+  ],
+};
+
+// --- URL helpers ---
+export function buildUrl(path, params) {
+  const url = `${BASE_URL}${path}`;
+  if (!params) return url;
+
+  const qs = Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  return `${url}?${qs}`;
+}
+
+// --- Endpoints ---
+export const ENDPOINTS = {
+  reservations: '/api/reservations',
+  revenueReport: '/api/reports/revenue',
+  occupancyReport: '/api/reports/occupancy',
+  search: '/api/search',
+  statsOverview: '/api/stats/overview',
+  queue: '/api/queue',
+  deposits: '/api/deposits',
+  clients: '/api/clients',
+};

--- a/k6/helpers/auth.js
+++ b/k6/helpers/auth.js
@@ -1,0 +1,57 @@
+// k6/helpers/auth.js — Login helper for k6 tests
+import http from 'k6/http';
+import { check } from 'k6';
+import { BASE_URL } from '../config.js';
+
+const TEST_USER = {
+  email: __ENV.TEST_USER_EMAIL || 'admin@test.com',
+  password: __ENV.TEST_USER_PASSWORD || 'admin123',
+};
+
+let cachedToken = null;
+
+/**
+ * Authenticate and return JWT token.
+ * Caches the token per VU so login is called once.
+ */
+export function login() {
+  if (cachedToken) return cachedToken;
+
+  const res = http.post(
+    `${BASE_URL}/api/auth/login`,
+    JSON.stringify(TEST_USER),
+    { headers: { 'Content-Type': 'application/json' } },
+  );
+
+  check(res, {
+    'login status 200': (r) => r.status === 200,
+    'login returns token': (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return !!body.token || !!body.accessToken;
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  try {
+    const body = JSON.parse(res.body);
+    cachedToken = body.token || body.accessToken;
+  } catch {
+    cachedToken = null;
+  }
+
+  return cachedToken;
+}
+
+/**
+ * Returns headers object with Authorization bearer token.
+ */
+export function getAuthHeaders() {
+  const token = login();
+  return {
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+}

--- a/k6/scenarios/load.js
+++ b/k6/scenarios/load.js
@@ -1,0 +1,55 @@
+// k6/scenarios/load.js — Load test: 50 VU, 30s plateau
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import { getAuthHeaders } from '../helpers/auth.js';
+import { buildUrl, thresholds, stages, ENDPOINTS } from '../config.js';
+
+const errorRate = new Rate('errors');
+const apiDuration = new Trend('api_duration', true);
+
+export const options = {
+  stages: stages.load,
+  thresholds,
+};
+
+export default function () {
+  const headers = getAuthHeaders();
+  const params = { headers };
+
+  group('Reservations', () => {
+    const res = http.get(buildUrl(ENDPOINTS.reservations), params);
+    check(res, { 'GET reservations 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.3);
+
+  group('Stats Overview', () => {
+    const res = http.get(buildUrl(ENDPOINTS.statsOverview), params);
+    check(res, { 'GET stats overview 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.3);
+
+  group('Queue', () => {
+    const res = http.get(buildUrl(ENDPOINTS.queue), params);
+    check(res, { 'GET queue 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.3);
+
+  group('Clients', () => {
+    const res = http.get(buildUrl(ENDPOINTS.clients), params);
+    check(res, { 'GET clients 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+}

--- a/k6/scenarios/smoke.js
+++ b/k6/scenarios/smoke.js
@@ -1,0 +1,99 @@
+// k6/scenarios/smoke.js — Smoke test: 1 VU, all critical endpoints once
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import { getAuthHeaders } from '../helpers/auth.js';
+import { buildUrl, ENDPOINTS } from '../config.js';
+
+const errorRate = new Rate('errors');
+const apiDuration = new Trend('api_duration', true);
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    errors: ['rate<0.1'],
+    http_req_duration: ['p(95)<2000'], // smoke is lenient
+  },
+};
+
+export default function () {
+  const headers = getAuthHeaders();
+  const params = { headers };
+
+  group('Reservations', () => {
+    const res = http.get(buildUrl(ENDPOINTS.reservations), params);
+    check(res, { 'GET reservations 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Revenue Report', () => {
+    const res = http.get(
+      buildUrl(ENDPOINTS.revenueReport, { dateFrom: '2024-01-01', dateTo: '2026-12-31' }),
+      params,
+    );
+    check(res, { 'GET revenue report 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Occupancy Report', () => {
+    const res = http.get(
+      buildUrl(ENDPOINTS.occupancyReport, { dateFrom: '2024-01-01', dateTo: '2026-12-31' }),
+      params,
+    );
+    check(res, { 'GET occupancy report 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Search', () => {
+    const res = http.get(buildUrl(ENDPOINTS.search, { q: 'test' }), params);
+    check(res, { 'GET search 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Stats Overview', () => {
+    const res = http.get(buildUrl(ENDPOINTS.statsOverview), params);
+    check(res, { 'GET stats overview 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Queue', () => {
+    const res = http.get(buildUrl(ENDPOINTS.queue), params);
+    check(res, { 'GET queue 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Deposits', () => {
+    const res = http.get(buildUrl(ENDPOINTS.deposits), params);
+    check(res, { 'GET deposits 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+
+  sleep(0.5);
+
+  group('Clients', () => {
+    const res = http.get(buildUrl(ENDPOINTS.clients), params);
+    check(res, { 'GET clients 200': (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+}

--- a/k6/scenarios/spike.js
+++ b/k6/scenarios/spike.js
@@ -1,0 +1,43 @@
+// k6/scenarios/spike.js — Spike test: 0 -> 100 VU instant, test recovery
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import { getAuthHeaders } from '../helpers/auth.js';
+import { buildUrl, stages, ENDPOINTS } from '../config.js';
+
+const errorRate = new Rate('errors');
+const apiDuration = new Trend('api_duration', true);
+
+export const options = {
+  stages: stages.spike,
+  thresholds: {
+    http_req_duration: ['p(95)<3000'],  // lenient — spike scenario
+    http_req_failed: ['rate<0.15'],     // allow up to 15% errors during spike
+  },
+};
+
+function hit(name, url, params) {
+  group(name, () => {
+    const res = http.get(url, params);
+    check(res, { [`${name} ok`]: (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+}
+
+export default function () {
+  const headers = getAuthHeaders();
+  const params = { headers };
+
+  hit('Reservations', buildUrl(ENDPOINTS.reservations), params);
+  sleep(0.1);
+
+  hit('Stats Overview', buildUrl(ENDPOINTS.statsOverview), params);
+  sleep(0.1);
+
+  hit('Queue', buildUrl(ENDPOINTS.queue), params);
+  sleep(0.1);
+
+  hit('Clients', buildUrl(ENDPOINTS.clients), params);
+  sleep(0.2);
+}

--- a/k6/scenarios/stress.js
+++ b/k6/scenarios/stress.js
@@ -1,0 +1,55 @@
+// k6/scenarios/stress.js — Stress test: ramp to 200 VU, find breaking points
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import { getAuthHeaders } from '../helpers/auth.js';
+import { buildUrl, stages, ENDPOINTS } from '../config.js';
+
+const errorRate = new Rate('errors');
+const apiDuration = new Trend('api_duration', true);
+
+export const options = {
+  stages: stages.stress,
+  thresholds: {
+    http_req_duration: ['p(95)<2000'],  // more lenient under stress
+    http_req_failed: ['rate<0.10'],     // allow up to 10% errors
+  },
+};
+
+function hit(name, url, params) {
+  group(name, () => {
+    const res = http.get(url, params);
+    check(res, { [`${name} ok`]: (r) => r.status === 200 });
+    errorRate.add(res.status !== 200);
+    apiDuration.add(res.timings.duration);
+  });
+}
+
+export default function () {
+  const headers = getAuthHeaders();
+  const params = { headers };
+
+  hit('Reservations', buildUrl(ENDPOINTS.reservations), params);
+  sleep(0.2);
+
+  hit('Revenue Report', buildUrl(ENDPOINTS.revenueReport, { dateFrom: '2024-01-01', dateTo: '2026-12-31' }), params);
+  sleep(0.2);
+
+  hit('Occupancy Report', buildUrl(ENDPOINTS.occupancyReport, { dateFrom: '2024-01-01', dateTo: '2026-12-31' }), params);
+  sleep(0.2);
+
+  hit('Search', buildUrl(ENDPOINTS.search, { q: 'test' }), params);
+  sleep(0.2);
+
+  hit('Stats Overview', buildUrl(ENDPOINTS.statsOverview), params);
+  sleep(0.2);
+
+  hit('Queue', buildUrl(ENDPOINTS.queue), params);
+  sleep(0.2);
+
+  hit('Deposits', buildUrl(ENDPOINTS.deposits), params);
+  sleep(0.2);
+
+  hit('Clients', buildUrl(ENDPOINTS.clients), params);
+  sleep(0.3);
+}


### PR DESCRIPTION
## Podsumowanie

Dodanie kompletnej infrastruktury testów wydajnościowych opartej na k6 (Grafana) dla systemu rezerwacji.

### Co zostało dodane:

- **`k6/config.js`** — wspólna konfiguracja: BASE_URL, thresholds (p95<500ms, error rate<1%, throughput>50 req/s), definicje stages, helper do budowania URL
- **`k6/helpers/auth.js`** — helper logowania: POST /api/auth/login, cache tokena JWT per VU, eksport `getAuthHeaders()`
- **`k6/scenarios/smoke.js`** — smoke test (1 VU): weryfikacja wszystkich 8 krytycznych endpointów (reservations, reports, search, stats, queue, deposits, clients)
- **`k6/scenarios/load.js`** — load test (50 VU, 30s): ramp-up 10s, plateau 30s, ramp-down 10s na najważniejszych endpointach
- **`k6/scenarios/stress.js`** — stress test (do 200 VU): szukanie breaking points
- **`k6/scenarios/spike.js`** — spike test (0->100 VU instant): test odporności na nagły wzrost ruchu
- **`.github/workflows/performance-tests.yml`** — CI workflow (workflow_dispatch, non-blocking), uruchamia smoke test z Postgres
- **`Makefile`** — nowe targety: `test-perf`, `test-perf-smoke`, `test-perf-load`, `test-perf-stress`, `test-perf-spike`

### Użycie lokalne:
```bash
make test-perf          # smoke (domyślny)
make test-perf-load     # 50 VU, 30s
make test-perf-stress   # do 200 VU
make test-perf-spike    # instant 100 VU
```

Zamyka #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)