### PR TITLE
feat(tests): visual regression tests — Playwright screenshots (#259)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,0 +1,142 @@
+name: Visual Regression Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      update_snapshots:
+        description: 'Zaktualizuj baseline screenshoty (--update-snapshots)'
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/frontend/**'
+
+concurrency:
+  group: visual-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  visual-regression:
+    name: Visual Regression Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: rezerwacje
+          POSTGRES_PASSWORD: rezerwacje_password
+          POSTGRES_DB: rezerwacje_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: |
+            apps/frontend/package-lock.json
+            apps/backend/package-lock.json
+
+      - name: Install backend dependencies
+        working-directory: apps/backend
+        run: npm ci
+
+      - name: Install frontend dependencies
+        working-directory: apps/frontend
+        run: |
+          npm ci --legacy-peer-deps
+          npx playwright install --with-deps chromium
+
+      - name: Setup environment
+        run: |
+          touch apps/frontend/e2e/.env.test
+          touch apps/backend/.env.test
+
+      - name: Setup database schema
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+        run: |
+          npx prisma generate
+          npx prisma db push --accept-data-loss --force-reset
+
+      - name: Seed test data
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+          NODE_ENV: development
+        run: npm run db:seed
+
+      - name: Start backend server
+        working-directory: apps/backend
+        env:
+          DATABASE_URL: postgresql://rezerwacje:rezerwacje_password@localhost:5432/rezerwacje_test
+          JWT_SECRET: ${{ secrets.JWT_SECRET_CI || 'e2e-ci-jwt-placeholder-not-production' }}
+          NODE_ENV: development
+        run: |
+          npx tsx src/index.ts &
+          npx wait-on http://localhost:3001/api/health --timeout 60000
+
+      - name: Build and start frontend
+        working-directory: apps/frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:3001/api
+        run: |
+          npm run build
+          npm start &
+          npx wait-on http://localhost:3000 --timeout 60000
+
+      - name: Run visual regression tests
+        working-directory: apps/frontend
+        env:
+          CI: true
+        run: |
+          EXTRA_ARGS=""
+          if [ "${{ github.event.inputs.update_snapshots }}" = "true" ]; then
+            EXTRA_ARGS="--update-snapshots"
+          fi
+          npx playwright test specs/12-visual-regression.spec.ts \
+            --project=chromium \
+            --retries=0 \
+            --reporter=html \
+            $EXTRA_ARGS
+
+      - name: Upload test results (diff images)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-results
+          path: apps/frontend/test-results/
+          retention-days: 30
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-report
+          path: apps/frontend/playwright-report/
+          retention-days: 30
+
+      - name: Upload updated screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-screenshots
+          path: apps/frontend/e2e/__screenshots__/
+          retention-days: 90
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 
 .PHONY: dev dev-build dev-down prod prod-build prod-down \
         test-unit test-integration test-security test-frontend test-e2e test-all \
+        test-visual test-visual-update \
         test-coverage test-frontend-coverage test-down \
         test-perf test-perf-smoke test-perf-load test-perf-stress test-perf-spike \
         migrate-minio migrate-minio-dry minio-stats minio-ls \
@@ -96,6 +97,12 @@ test-e2e-ui:
 
 test-e2e-headed:
 	cd apps/frontend && npx playwright test --headed
+
+test-visual:
+	cd apps/frontend && npx playwright test specs/12-visual-regression.spec.ts --project=chromium
+
+test-visual-update:
+	cd apps/frontend && npx playwright test specs/12-visual-regression.spec.ts --project=chromium --update-snapshots
 
 test-all: test-unit test-integration test-security test-frontend
 
@@ -245,6 +252,8 @@ help:
 	@echo "    make test-frontend      Frontend component tests (Vitest)"
 	@echo "    make test-coverage      Backend tests with coverage"
 	@echo "    make test-e2e           E2E tests (Playwright, needs make dev)"
+	@echo "    make test-visual        Visual regression tests (Playwright screenshots)"
+	@echo "    make test-visual-update Update visual regression baseline screenshots"
 	@echo "    make test-all           All tests (unit + integration + frontend)"
 	@echo "    make test-down          Stop test containers"
 	@echo ""

--- a/apps/frontend/e2e/specs/12-visual-regression.spec.ts
+++ b/apps/frontend/e2e/specs/12-visual-regression.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect } from '@playwright/test';
+import { manualLogin as login } from '../fixtures/auth.fixture';
+
+/**
+ * VISUAL REGRESSION TESTS
+ *
+ * Porownuje screenshoty kluczowych widokow z baseline (golden files).
+ * Przy pierwszym uruchomieniu Playwright automatycznie tworzy pliki referencyjne.
+ * Kolejne uruchomienia porownuja z baseline i raportuja roznice.
+ *
+ * Aby zaktualizowac baseline:
+ *   npx playwright test specs/12-visual-regression.spec.ts --update-snapshots
+ *
+ * UWAGA: Nie uzywamy waitForLoadState('networkidle') — moze wisiec
+ * na mobilnym Safari (patrz auth.fixture.ts).
+ */
+
+const SNAPSHOT_OPTIONS = {
+  maxDiffPixelRatio: 0.01,
+  fullPage: true,
+};
+
+/**
+ * Czeka az strona sie ustabilizuje po nawigacji.
+ * Uzywa domcontentloaded + dodatkowy timeout na animacje/renderowanie.
+ */
+async function waitForPageStable(page: import('@playwright/test').Page) {
+  await page.waitForLoadState('domcontentloaded');
+  // Daj czas na renderowanie komponentow i zakonczenie animacji CSS
+  await page.waitForTimeout(1000);
+}
+
+test.describe('Visual Regression - Strona logowania', () => {
+  test('strona logowania renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/login');
+    await waitForPageStable(page);
+
+    await expect(page).toHaveScreenshot('login-page.png', SNAPSHOT_OPTIONS);
+  });
+});
+
+test.describe('Visual Regression - Dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'admin@gosciniecrodzinny.pl', 'Admin123!@#');
+  });
+
+  test('dashboard renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForPageStable(page);
+
+    // Poczekaj na zaladowanie naglowka powitalnego
+    await expect(
+      page.getByRole('heading', { name: /Witaj/ })
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(page).toHaveScreenshot('dashboard.png', SNAPSHOT_OPTIONS);
+  });
+
+  test('dashboard dark mode renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard');
+    await waitForPageStable(page);
+
+    await expect(
+      page.getByRole('heading', { name: /Witaj/ })
+    ).toBeVisible({ timeout: 10000 });
+
+    // Przelacz na dark mode — szukamy przycisku toggle motywu
+    const themeToggle = page.locator(
+      'button[aria-label*="motyw"], button[aria-label*="theme"], button[aria-label*="tryb"], [data-testid="theme-toggle"]'
+    );
+
+    if (await themeToggle.isVisible().catch(() => false)) {
+      await themeToggle.click();
+      await page.waitForTimeout(500);
+    } else {
+      // Fallback: wymus dark mode przez CSS prefers-color-scheme
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.waitForTimeout(500);
+    }
+
+    await expect(page).toHaveScreenshot('dashboard-dark.png', SNAPSHOT_OPTIONS);
+  });
+});
+
+test.describe('Visual Regression - Rezerwacje', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'admin@gosciniecrodzinny.pl', 'Admin123!@#');
+  });
+
+  test('kalendarz rezerwacji renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard/reservations/calendar');
+    await waitForPageStable(page);
+
+    // Poczekaj na kalendarz
+    await page.waitForTimeout(2000);
+
+    await expect(page).toHaveScreenshot('reservations-calendar.png', SNAPSHOT_OPTIONS);
+  });
+
+  test('lista rezerwacji renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard/reservations/list');
+    await waitForPageStable(page);
+
+    await expect(page).toHaveScreenshot('reservations-list.png', SNAPSHOT_OPTIONS);
+  });
+
+  test('formularz nowej rezerwacji renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard/reservations');
+    await waitForPageStable(page);
+
+    // Szukaj przycisku "Nowa rezerwacja" / "Dodaj" i kliknij
+    const newReservationBtn = page.locator(
+      'a:has-text("Nowa rezerwacja"), button:has-text("Nowa rezerwacja"), a:has-text("Dodaj"), button:has-text("Dodaj rezerwacj")'
+    );
+
+    if (await newReservationBtn.first().isVisible().catch(() => false)) {
+      await newReservationBtn.first().click();
+      await waitForPageStable(page);
+    }
+
+    await expect(page).toHaveScreenshot('reservation-form.png', SNAPSHOT_OPTIONS);
+  });
+});
+
+test.describe('Visual Regression - Klienci', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'admin@gosciniecrodzinny.pl', 'Admin123!@#');
+  });
+
+  test('lista klientow renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard/clients');
+    await waitForPageStable(page);
+
+    await expect(page).toHaveScreenshot('clients-list.png', SNAPSHOT_OPTIONS);
+  });
+});
+
+test.describe('Visual Regression - Ustawienia', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'admin@gosciniecrodzinny.pl', 'Admin123!@#');
+  });
+
+  test('panel ustawien - zakladka uzytkownicy', async ({ page }) => {
+    await page.goto('/dashboard/settings');
+    await waitForPageStable(page);
+
+    // Domyslnie otwarta jest zakladka "users"
+    await expect(page).toHaveScreenshot('settings-users.png', SNAPSHOT_OPTIONS);
+  });
+
+  test('panel ustawien - zakladka role', async ({ page }) => {
+    await page.goto('/dashboard/settings');
+    await waitForPageStable(page);
+
+    // Kliknij zakladke "Role i uprawnienia"
+    const rolesTab = page.locator('[value="roles"]');
+    await rolesTab.click();
+    await page.waitForTimeout(500);
+
+    await expect(page).toHaveScreenshot('settings-roles.png', SNAPSHOT_OPTIONS);
+  });
+});
+
+test.describe('Visual Regression - Kolejka', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'admin@gosciniecrodzinny.pl', 'Admin123!@#');
+  });
+
+  test('widok kolejki renderuje sie poprawnie', async ({ page }) => {
+    await page.goto('/dashboard/queue');
+    await waitForPageStable(page);
+
+    await expect(page).toHaveScreenshot('queue.png', SNAPSHOT_OPTIONS);
+  });
+});

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -60,7 +60,13 @@ export default defineConfig({
   /* Timeout for expect() assertions */
   expect: {
     timeout: 5000,
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+    },
   },
+
+  /* Directory for visual regression snapshots */
+  snapshotPathTemplate: '{testDir}/__screenshots__/{testFilePath}/{arg}{ext}',
   
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
## Summary
- Dodaje **10 visual regression testow** porownujacych screenshoty kluczowych widokow z baseline (golden files)
- Nowy CI workflow `visual-regression.yml` z opcja `workflow_dispatch` do aktualizacji baseline
- Targety Makefile: `test-visual` / `test-visual-update`

## Testowane widoki
1. Strona logowania
2. Dashboard
3. Dashboard (dark mode)
4. Kalendarz rezerwacji
5. Lista rezerwacji
6. Formularz nowej rezerwacji
7. Lista klientow
8. Panel ustawien — zakladka Uzytkownicy
9. Panel ustawien — zakladka Role
10. Widok kolejki

## Zmiany w plikach
- `apps/frontend/e2e/specs/12-visual-regression.spec.ts` — spec z testami
- `apps/frontend/playwright.config.ts` — `toHaveScreenshot` config + `snapshotPathTemplate`
- `.github/workflows/visual-regression.yml` — CI workflow (nie blokuje merge, `continue-on-error`)
- `Makefile` — targety `test-visual` / `test-visual-update`

## Po merge
Testy beda failowac bez golden files — to **normalne** przy pierwszym uruchomieniu.
Aby wygenerowac baseline:
1. Uruchom workflow reczenie z `update_snapshots: true` (Actions -> Visual Regression Tests -> Run workflow)
2. Lub lokalnie: `make test-visual-update`
3. Pobierz artefakt `visual-regression-screenshots` i commitnij do repo

## Test plan
- [ ] CI workflow uruchamia sie na PR do `apps/frontend/**`
- [ ] `workflow_dispatch` z `update_snapshots=true` generuje baseline
- [ ] Screenshoty uploaduja sie jako artefakty
- [ ] `make test-visual` dziala lokalnie

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)