### PR TITLE
fix(ci): timeout codecov upload — napraw 47min hang

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -94,10 +94,13 @@ jobs:
       - name: Upload Unit Test Coverage
         if: always()
         uses: codecov/codecov-action@v4
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           files: ./apps/backend/coverage/lcov.info
           flags: backend-unit
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ========================================
   # Job 3: Integration Tests (with PostgreSQL)
@@ -154,10 +157,13 @@ jobs:
       - name: Upload Integration Test Coverage
         if: always()
         uses: codecov/codecov-action@v4
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           files: ./apps/backend/coverage/lcov.info
           flags: backend-integration
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ========================================
   # Job 4: Security Tests (with PostgreSQL)

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -65,10 +65,13 @@ jobs:
       - name: Upload Component Test Coverage
         if: always()
         uses: codecov/codecov-action@v4
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           files: ./apps/frontend/coverage/lcov.info
           flags: frontend-components
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ========================================
   # Job 3: Contract Tests (API response shape validation)


### PR DESCRIPTION
## Problem
Codecov tokenless upload wisiał ~47 minut blokując `component-tests` job.

## Rozwiązanie
- `timeout-minutes: 2` — max 2 minuty na upload
- `continue-on-error: true` — nie blokuje pipeline przy failure
- `token: ${{ secrets.CODECOV_TOKEN }}` — preferuj token z secrets

## Dotyczy
- `.github/workflows/frontend-tests.yml` — 1 codecov step
- `.github/workflows/backend-ci.yml` — 2 codecov steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)