### PR TITLE
fix(k6): napraw performance testy — credentials, wait-on, trigger (#271)

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -2,6 +2,9 @@ name: Performance Tests (k6)
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['k6/**', '.github/workflows/performance-tests.yml']
 
 concurrency:
   group: perf-tests-${{ github.ref }}
@@ -74,7 +77,16 @@ jobs:
           NODE_ENV: development
         run: |
           npx tsx src/index.ts &
-          npx wait-on http://localhost:3001/api/health --timeout 60000
+          echo "Waiting for backend to be ready..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:3001/api/health > /dev/null 2>&1; then
+              echo "Backend is ready!"
+              break
+            fi
+            echo "Attempt $i/60 — waiting..."
+            sleep 2
+          done
+          curl -sf http://localhost:3001/api/health || (echo "Backend failed to start" && exit 1)
 
       - name: Run k6 smoke test
         run: |

--- a/k6/config.js
+++ b/k6/config.js
@@ -12,7 +12,7 @@ export const thresholds = {
 
 // --- Stage presets ---
 export const stages = {
-  smoke: [{ duration: '1s', target: 1 }],
+  smoke: [{ duration: '10s', target: 1 }],
 
   load: [
     { duration: '10s', target: 50 },  // ramp-up

--- a/k6/helpers/auth.js
+++ b/k6/helpers/auth.js
@@ -4,8 +4,8 @@ import { check } from 'k6';
 import { BASE_URL } from '../config.js';
 
 const TEST_USER = {
-  email: __ENV.TEST_USER_EMAIL || 'admin@test.com',
-  password: __ENV.TEST_USER_PASSWORD || 'admin123',
+  email: __ENV.TEST_USER_EMAIL || 'admin@gosciniecrodzinny.pl',
+  password: __ENV.TEST_USER_PASSWORD || 'Admin123!@#',
 };
 
 let cachedToken = null;


### PR DESCRIPTION
## Summary
- Dodano `push` trigger na `main` (paths: `k6/**`, workflow) obok istniejącego `workflow_dispatch`
- Naprawiono dane logowania w k6 auth helper — teraz matchują faktyczny seed (`admin@gosciniecrodzinny.pl` / `Admin123!@#`)
- Zastąpiono `npx wait-on` (brak w dependencies) curl-based health-check loop (max 120s)
- Zwiększono smoke stage duration z 1s do 10s (wystarczający czas na auth + requesty)

## Test plan
- [ ] Uruchom workflow ręcznie na tym branchu (`workflow_dispatch`)
- [ ] Smoke test powinien przejść bez 401/auth errors
- [ ] Backend powinien się uruchomić bez błędu `wait-on: not found`

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)