### PR TITLE
fix(a11y): napraw 20 failujących testów E2E (#273)

### DIFF
--- a/apps/frontend/app/dashboard/halls/page.tsx
+++ b/apps/frontend/app/dashboard/halls/page.tsx
@@ -58,7 +58,7 @@ export default function HallsPage() {
         icon={Building2}
         action={
           <Link href="/dashboard/halls/new">
-            <Button size="lg" className="bg-white text-sky-600 hover:bg-white/90 shadow-xl">
+            <Button size="lg" className="bg-white text-sky-700 hover:bg-white/90 shadow-xl">
               <Plus className="mr-2 h-5 w-5" />
               Dodaj Salę
             </Button>

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -38,7 +38,7 @@ const statusLabels: Record<string, { label: string; emoji: string; classes: stri
   RESERVED: {
     label: 'W kolejce',
     emoji: '📋',
-    classes: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    classes: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
   },
   COMPLETED: {
     label: 'Zakończone',
@@ -344,12 +344,12 @@ export default function DashboardPage() {
                       {event.guests > 0 && ` • ${event.guests} os.`}
                     </p>
                     {Number(event.totalPrice) > 0 && (
-                      <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">
+                      <p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1">
                         💰 Wartość: {formatCurrency(Number(event.totalPrice))}
                       </p>
                     )}
                     {pendingDepositTotal > 0 && (
-                      <p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5">
+                      <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
                         ⚠️ Zaliczka do zapłaty: {formatCurrency(pendingDepositTotal)}
                       </p>
                     )}

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -14,8 +14,8 @@
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
 
-    /* Primary = Indigo-600 */
-    --primary: 239 84% 67%;
+    /* Primary = Indigo-600 (WCAG AA compliant with primary-foreground) */
+    --primary: 239 84% 59%;
     --primary-foreground: 0 0% 98%;
 
     /* Secondary = Purple-100 */
@@ -23,7 +23,7 @@
     --secondary-foreground: 0 0% 9%;
 
     --muted: 0 0% 96.1%;
-    --muted-foreground: 0 0% 45.1%;
+    --muted-foreground: 0 0% 40%;
 
     --accent: 0 0% 96.1%;
     --accent-foreground: 0 0% 9%;

--- a/apps/frontend/components/deposits/deposit-actions.tsx
+++ b/apps/frontend/components/deposits/deposit-actions.tsx
@@ -176,7 +176,7 @@ export function DepositActions({ deposit, onUpdate }: DepositActionsProps) {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0 hover:bg-neutral-100 dark:hover:bg-neutral-800">
+          <Button variant="ghost" size="sm" className="h-8 w-8 p-0 hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Akcje zaliczki">
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/frontend/components/event-types/event-type-card.tsx
+++ b/apps/frontend/components/event-types/event-type-card.tsx
@@ -102,6 +102,7 @@ export function EventTypeCard({ eventType, stats, onUpdate, onEdit, onDelete }: 
                     ? 'opacity-100'
                     : 'opacity-0 group-hover:opacity-100'
                 }`}
+                aria-label={`Opcje dla ${eventType.name}`}
               >
                 <MoreHorizontal className="h-4 w-4" />
               </Button>
@@ -158,6 +159,7 @@ export function EventTypeCard({ eventType, stats, onUpdate, onEdit, onDelete }: 
               checked={eventType.isActive}
               onCheckedChange={handleToggleActive}
               disabled={toggling}
+              aria-label={`Przełącz aktywność ${eventType.name}`}
             />
           </div>
         </div>

--- a/apps/frontend/components/halls/hall-card.tsx
+++ b/apps/frontend/components/halls/hall-card.tsx
@@ -195,7 +195,7 @@ export function HallCard({ hall, onUpdate }: HallCardProps) {
             <Users className="h-4 w-4 text-white" />
           </div>
           <div>
-            <div className="text-xs text-neutral-500 dark:text-neutral-400 font-medium">Pojemność</div>
+            <div className="text-xs text-neutral-600 dark:text-neutral-400 font-medium">Pojemność</div>
             <div className="text-lg font-bold text-neutral-900 dark:text-neutral-100">{hall.capacity} osób</div>
           </div>
         </div>

--- a/apps/frontend/components/layout/Header.tsx
+++ b/apps/frontend/components/layout/Header.tsx
@@ -142,12 +142,12 @@ export default function Header({ user, onMenuClick }: HeaderProps) {
           {/* Search — hidden on small mobile */}
           <button
             onClick={() => setSearchOpen(true)}
-            className="hidden sm:flex items-center gap-2 rounded-xl bg-neutral-100 dark:bg-neutral-800/80 px-4 py-2 text-sm text-neutral-500 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-all duration-200 hover:-translate-y-0.5"
+            className="hidden sm:flex items-center gap-2 rounded-xl bg-neutral-100 dark:bg-neutral-800/80 px-4 py-2 text-sm text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-all duration-200 hover:-translate-y-0.5"
             aria-label="Szukaj"
           >
             <Search className="h-4 w-4" />
             <span className="hidden md:inline">Szukaj...</span>
-            <kbd className="hidden md:inline-flex items-center gap-1 rounded-md bg-neutral-200/80 dark:bg-neutral-700 px-1.5 py-0.5 text-[10px] font-medium text-neutral-500 dark:text-neutral-400">
+            <kbd className="hidden md:inline-flex items-center gap-1 rounded-md bg-neutral-200/80 dark:bg-neutral-700 px-1.5 py-0.5 text-[10px] font-medium text-neutral-600 dark:text-neutral-400">
               ⌘K
             </kbd>
           </button>

--- a/apps/frontend/components/reservations/create-form/EventSection.tsx
+++ b/apps/frontend/components/reservations/create-form/EventSection.tsx
@@ -40,7 +40,7 @@ export function EventSection({
           control={control}
           render={({ field }) => (
             <Select value={field.value} onValueChange={field.onChange}>
-              <SelectTrigger className={`h-11 ${errors.eventTypeId ? 'border-red-400 dark:border-red-500' : ''}`}>
+              <SelectTrigger className={`h-11 ${errors.eventTypeId ? 'border-red-400 dark:border-red-500' : ''}`} aria-label="Wybierz typ wydarzenia">
                 <SelectValue placeholder="Wybierz typ wydarzenia..." />
               </SelectTrigger>
               <SelectContent>

--- a/apps/frontend/components/reservations/create-form/MenuSection.tsx
+++ b/apps/frontend/components/reservations/create-form/MenuSection.tsx
@@ -99,7 +99,7 @@ export function MenuSection({
                 field.onChange(val)
                 setValue('menuPackageId', '')
               }}>
-                <SelectTrigger className="h-11 bg-white dark:bg-neutral-900">
+                <SelectTrigger className="h-11 bg-white dark:bg-neutral-900" aria-label="Wybierz szablon menu">
                   <SelectValue placeholder={menuTemplatesLoading ? 'Ładowanie szablonów...' : 'Wybierz szablon menu...'} />
                 </SelectTrigger>
                 <SelectContent>
@@ -151,7 +151,7 @@ export function MenuSection({
               ) : (
                 <Controller name="menuPackageId" control={control} render={({ field }) => (
                   <Select value={field.value || ''} onValueChange={field.onChange}>
-                    <SelectTrigger className="h-11 bg-white dark:bg-neutral-900">
+                    <SelectTrigger className="h-11 bg-white dark:bg-neutral-900" aria-label="Wybierz pakiet menu">
                       <SelectValue placeholder="Wybierz pakiet..." />
                     </SelectTrigger>
                     <SelectContent>

--- a/apps/frontend/components/reservations/create-form/VenueSection.tsx
+++ b/apps/frontend/components/reservations/create-form/VenueSection.tsx
@@ -56,7 +56,7 @@ export function VenueSection({
           control={control}
           render={({ field }) => (
             <Select value={field.value} onValueChange={field.onChange}>
-              <SelectTrigger className={`h-11 ${errors.hallId ? 'border-red-400 dark:border-red-500' : ''}`}>
+              <SelectTrigger className={`h-11 ${errors.hallId ? 'border-red-400 dark:border-red-500' : ''}`} aria-label="Wybierz salę">
                 <SelectValue placeholder="Wybierz salę..." />
               </SelectTrigger>
               <SelectContent>

--- a/apps/frontend/components/reservations/reservations-list.tsx
+++ b/apps/frontend/components/reservations/reservations-list.tsx
@@ -223,7 +223,7 @@ export function ReservationsList() {
       <div className="flex flex-wrap items-center gap-3">
         <div className="w-full sm:w-64">
           <Select value={statusFilter} onValueChange={(value) => setStatusFilter(value as ReservationStatus | 'ALL')}>
-            <SelectTrigger className="h-11 rounded-xl border-neutral-200 dark:border-neutral-700">
+            <SelectTrigger className="h-11 rounded-xl border-neutral-200 dark:border-neutral-700" aria-label="Filtruj po statusie">
               <SelectValue placeholder="Filtruj po statusie" />
             </SelectTrigger>
             <SelectContent className="rounded-xl">

--- a/apps/frontend/components/settings/UsersTab.tsx
+++ b/apps/frontend/components/settings/UsersTab.tsx
@@ -132,8 +132,8 @@ export function UsersTab() {
                   <TableCell>
                     {user.role ? (
                       <Badge
-                        variant="outline"
-                        style={{ borderColor: user.role.color, color: user.role.color }}
+                        className="font-semibold border-transparent text-white shadow-sm"
+                        style={{ backgroundColor: user.role.color }}
                       >
                         {user.role.name}
                       </Badge>

--- a/apps/frontend/components/shared/StatCard.tsx
+++ b/apps/frontend/components/shared/StatCard.tsx
@@ -100,7 +100,7 @@ export function StatCard({
                     <span
                       className={cn(
                         'text-sm font-medium',
-                        changeType === 'positive' && 'text-emerald-600 dark:text-emerald-400',
+                        changeType === 'positive' && 'text-emerald-700 dark:text-emerald-400',
                         changeType === 'negative' && 'text-red-600 dark:text-red-400',
                         changeType === 'neutral' && 'text-neutral-500 dark:text-neutral-400'
                       )}

--- a/apps/frontend/e2e/accessibility.spec.ts
+++ b/apps/frontend/e2e/accessibility.spec.ts
@@ -13,8 +13,25 @@ import AxeBuilder from '@axe-core/playwright';
 const EXCLUDED_SELECTORS =
   '.recharts-wrapper, .rdp, [data-radix-popper-content-wrapper]';
 
+/** Helper: disable CSS animations/transitions so axe doesn't scan mid-animation. */
+async function disableAnimations(page: import('@playwright/test').Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation-duration: 0s !important;
+        animation-delay: 0s !important;
+        transition-duration: 0s !important;
+        transition-delay: 0s !important;
+      }
+    `,
+  });
+  // Small wait to let forced-instant animations settle
+  await page.waitForTimeout(500);
+}
+
 /** Helper: run axe on the current page and return the results. */
 async function scanPage(page: import('@playwright/test').Page) {
+  await disableAnimations(page);
   return new AxeBuilder({ page })
     .withTags(['wcag2a', 'wcag2aa'])
     .exclude(EXCLUDED_SELECTORS)

--- a/apps/frontend/e2e/history.spec.ts
+++ b/apps/frontend/e2e/history.spec.ts
@@ -159,11 +159,9 @@ test.describe('History and Audit Trail', () => {
 
       // Wait for the timeline to finish loading (skeleton disappears)
       // Then either timeline entries or empty state should be visible
+      // Use regex locator to avoid strict mode violation with .or().first() chaining
       await expect(
-        page.locator('text=Utworzenie').first()
-          .or(page.locator('text=Aktualizacja').first())
-          .or(page.locator('text=Zmiana statusu').first())
-          .or(page.locator('text=Brak historii zmian'))
+        page.locator('text=/Utworzenie|Aktualizacja|Zmiana statusu|Brak historii zmian/').first()
       ).toBeVisible({ timeout: 15000 });
     });
 


### PR DESCRIPTION
## Summary
- Naprawia **10 z 20** failujących testów E2E (Full E2E suite):
  - **9x accessibility.spec.ts** — violations `color-contrast` (WCAG AA) i `button-name`
  - **1x history.spec.ts** — strict mode violation w Playwright `.or()` chainingu
- Pozostałe **10x 12-visual-regression.spec.ts** to brak baseline screenshots — osobny issue

## Zmiany w komponentach (a11y)
| Problem | Naprawione pliki | Co zmieniono |
|---------|-----------------|-------------|
| `color-contrast` Search bar | `Header.tsx` | `text-neutral-500` → `text-neutral-600` |
| `color-contrast` StatCard | `StatCard.tsx` | `text-emerald-600` → `text-emerald-700` |
| `color-contrast` Dashboard events | `page.tsx` (dashboard) | `text-neutral-500/amber-600/blue-700` → ciemniejsze warianty |
| `color-contrast` Halls | `halls/page.tsx`, `hall-card.tsx` | `text-sky-600` → `sky-700`, `neutral-500` → `neutral-600` |
| `color-contrast` Settings tabs | `globals.css` | `--muted-foreground: 45.1%` → `40%` |
| `color-contrast` Settings badges | `globals.css`, `UsersTab.tsx` | `--primary: 67%` → `59%`, role badge → bg fill |
| `button-name` Select triggers | `EventSection.tsx`, `VenueSection.tsx`, `MenuSection.tsx`, `reservations-list.tsx` | dodano `aria-label` |
| `button-name` DropdownMenu | `event-type-card.tsx`, `deposit-actions.tsx` | dodano `aria-label` |
| `button-name` Switch | `event-type-card.tsx` | dodano `aria-label` |

## Zmiany w testach
- `accessibility.spec.ts` — `disableAnimations()` helper wyłącza CSS transitions/animations przed axe scan (eliminuje false positives z Framer Motion)
- `history.spec.ts` — regex locator zamiast `.or().first()` chaining (naprawia strict mode violation)

## Test plan
- [ ] Smoke Tests muszą przejść (blocking)
- [ ] Full E2E Tests — spadek z 20 na ~10 failures (10 to visual-regression, osobny issue)
- [ ] Weryfikacja wizualna — kolory minimalnie ciemniejsze, bez widocznej zmiany designu

🤖 Generated with [Claude Code](https://claude.com/claude-code)