### PR TITLE
feat(tests): unit testy dla 3 controllerów + validateBody middleware

### DIFF
--- a/apps/backend/src/tests/unit/controllers/archive-admin.controller.test.ts
+++ b/apps/backend/src/tests/unit/controllers/archive-admin.controller.test.ts
@@ -1,0 +1,260 @@
+/**
+ * ArchiveAdminController — Unit Tests
+ *
+ * Covers: getArchiveSettings, updateArchiveSettings, runArchiveNow
+ */
+
+// ─── Mocks ───────────────────────────────────────────────
+const mockFindFirst = jest.fn();
+const mockCount = jest.fn();
+const mockUpdate = jest.fn();
+const mockLogChange = jest.fn().mockResolvedValue(undefined);
+const mockArchiveCancelled = jest.fn();
+
+jest.mock('../../../lib/prisma', () => ({
+  prisma: {
+    companySettings: {
+      findFirst: (...args: any[]) => mockFindFirst(...args),
+      update: (...args: any[]) => mockUpdate(...args),
+    },
+    reservation: {
+      count: (...args: any[]) => mockCount(...args),
+    },
+  },
+}));
+
+jest.mock('../../../utils/audit-logger', () => ({
+  logChange: (...args: any[]) => mockLogChange(...args),
+}));
+
+jest.mock('../../../utils/logger', () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../../../services/archive-scheduler.service', () => ({
+  __esModule: true,
+  default: {
+    archiveCancelled: (...args: any[]) => mockArchiveCancelled(...args),
+  },
+}));
+
+import { ArchiveAdminController } from '../../../controllers/archive-admin.controller';
+
+// ─── Helpers ─────────────────────────────────────────────
+const controller = new ArchiveAdminController();
+
+const req = (overrides: any = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  user: { id: 'user-1' },
+  ...overrides,
+});
+
+const res = () => {
+  const r: any = {};
+  r.status = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  return r;
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ─── Tests ───────────────────────────────────────────────
+describe('ArchiveAdminController', () => {
+  // ═══════════════════════════════════════════════════════
+  // getArchiveSettings
+  // ═══════════════════════════════════════════════════════
+  describe('getArchiveSettings()', () => {
+    it('should return settings with counts and default archiveAfterDays=30 when no settings', async () => {
+      mockFindFirst.mockResolvedValue(null);
+      mockCount
+        .mockResolvedValueOnce(5)   // pendingCandidatesCount
+        .mockResolvedValueOnce(10)  // totalCancelledCount
+        .mockResolvedValueOnce(20); // archivedTotalCount
+
+      const response = res();
+      await controller.getArchiveSettings(req(), response);
+
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: expect.objectContaining({
+            archiveAfterDays: 30,
+            pendingCandidatesCount: 5,
+            totalCancelledCount: 10,
+            archivedTotalCount: 20,
+            cutoffDate: expect.any(String),
+          }),
+        })
+      );
+    });
+
+    it('should use archiveAfterDays from settings when present', async () => {
+      mockFindFirst.mockResolvedValue({ archiveAfterDays: 60 });
+      mockCount.mockResolvedValue(0);
+
+      const response = res();
+      await controller.getArchiveSettings(req(), response);
+
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ archiveAfterDays: 60 }),
+        })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // updateArchiveSettings
+  // ═══════════════════════════════════════════════════════
+  describe('updateArchiveSettings()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.updateArchiveSettings(req({ user: undefined }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when archiveAfterDays missing', async () => {
+      await expect(
+        controller.updateArchiveSettings(req({ body: {} }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when archiveAfterDays is 0', async () => {
+      await expect(
+        controller.updateArchiveSettings(req({ body: { archiveAfterDays: 0 } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when archiveAfterDays > 365', async () => {
+      await expect(
+        controller.updateArchiveSettings(req({ body: { archiveAfterDays: 400 } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when archiveAfterDays is NaN', async () => {
+      await expect(
+        controller.updateArchiveSettings(req({ body: { archiveAfterDays: 'abc' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 404 when companySettings not found', async () => {
+      mockFindFirst.mockResolvedValue(null);
+
+      await expect(
+        controller.updateArchiveSettings(req({ body: { archiveAfterDays: 45 } }), res())
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it('should update settings and log change on valid input', async () => {
+      mockFindFirst.mockResolvedValue({ id: 'cs-1', archiveAfterDays: 30 });
+      mockUpdate.mockResolvedValue({ archiveAfterDays: 45 });
+
+      const response = res();
+      await controller.updateArchiveSettings(
+        req({ body: { archiveAfterDays: 45 } }), response
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'cs-1' },
+          data: { archiveAfterDays: 45 },
+        })
+      );
+      expect(mockLogChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          action: 'ARCHIVE_SETTINGS_UPDATED',
+          entityType: 'CompanySettings',
+          entityId: 'cs-1',
+        })
+      );
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: { archiveAfterDays: 45 },
+        })
+      );
+    });
+
+    it('should parse string archiveAfterDays to number', async () => {
+      mockFindFirst.mockResolvedValue({ id: 'cs-1', archiveAfterDays: 30 });
+      mockUpdate.mockResolvedValue({ archiveAfterDays: 90 });
+
+      const response = res();
+      await controller.updateArchiveSettings(
+        req({ body: { archiveAfterDays: '90' } }), response
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { archiveAfterDays: 90 } })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // runArchiveNow
+  // ═══════════════════════════════════════════════════════
+  describe('runArchiveNow()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.runArchiveNow(req({ user: undefined }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should run archive and return result with message (archivedCount > 0)', async () => {
+      const archiveResult = {
+        archivedCount: 3,
+        archivedIds: ['r-1', 'r-2', 'r-3'],
+        archiveAfterDays: 30,
+      };
+      mockArchiveCancelled.mockResolvedValue(archiveResult);
+
+      const response = res();
+      await controller.runArchiveNow(req(), response);
+
+      expect(mockArchiveCancelled).toHaveBeenCalled();
+      expect(mockLogChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: 'MANUAL_ARCHIVE_RUN',
+          entityType: 'RESERVATION',
+          entityId: 'BATCH',
+          details: expect.objectContaining({
+            archivedCount: 3,
+            triggeredBy: 'ADMIN_PANEL',
+          }),
+        })
+      );
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: archiveResult,
+        })
+      );
+    });
+
+    it('should return appropriate message when no reservations archived', async () => {
+      const archiveResult = {
+        archivedCount: 0,
+        archivedIds: [],
+        archiveAfterDays: 30,
+      };
+      mockArchiveCancelled.mockResolvedValue(archiveResult);
+
+      const response = res();
+      await controller.runArchiveNow(req(), response);
+
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Brak rezerwacji do archiwizacji',
+        })
+      );
+    });
+  });
+});

--- a/apps/backend/src/tests/unit/controllers/document-template.controller.test.ts
+++ b/apps/backend/src/tests/unit/controllers/document-template.controller.test.ts
@@ -1,0 +1,433 @@
+/**
+ * DocumentTemplateController — Unit Tests
+ *
+ * Covers: list, getBySlug, create, update, delete, restore, preview, getHistory
+ */
+
+jest.mock('../../../services/document-template.service', () => ({
+  __esModule: true,
+  default: {
+    list: jest.fn(),
+    getBySlug: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    restore: jest.fn(),
+    preview: jest.fn(),
+    getHistory: jest.fn(),
+  },
+}));
+
+import documentTemplateController from '../../../controllers/document-template.controller';
+import documentTemplateService from '../../../services/document-template.service';
+
+const svc = documentTemplateService as any;
+
+// ─── Helpers ─────────────────────────────────────────────
+const req = (overrides: any = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  user: { id: 'user-1' },
+  ...overrides,
+});
+
+const res = () => {
+  const r: any = {};
+  r.status = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  return r;
+};
+
+const next = jest.fn();
+
+beforeEach(() => jest.clearAllMocks());
+
+// ─── Tests ───────────────────────────────────────────────
+describe('DocumentTemplateController', () => {
+  // ═══════════════════════════════════════════════════════
+  // list
+  // ═══════════════════════════════════════════════════════
+  describe('list()', () => {
+    it('should return all templates', async () => {
+      const templates = [{ id: 't1', slug: 'invoice' }];
+      svc.list.mockResolvedValue(templates);
+
+      const response = res();
+      await documentTemplateController.list(req(), response, next);
+
+      expect(svc.list).toHaveBeenCalledWith({ category: undefined });
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: true,
+          data: templates,
+          count: 1,
+        })
+      );
+    });
+
+    it('should pass category query param', async () => {
+      svc.list.mockResolvedValue([]);
+
+      await documentTemplateController.list(
+        req({ query: { category: 'RESERVATION_PDF' } }), res(), next
+      );
+
+      expect(svc.list).toHaveBeenCalledWith({ category: 'RESERVATION_PDF' });
+    });
+
+    it('should call next on error', async () => {
+      const error = new Error('DB error');
+      svc.list.mockRejectedValue(error);
+
+      await documentTemplateController.list(req(), res(), next);
+
+      expect(next).toHaveBeenCalledWith(error);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // getBySlug
+  // ═══════════════════════════════════════════════════════
+  describe('getBySlug()', () => {
+    it('should return template by slug', async () => {
+      const tpl = { id: 't1', slug: 'invoice', content: '<html>' };
+      svc.getBySlug.mockResolvedValue(tpl);
+
+      const response = res();
+      await documentTemplateController.getBySlug(
+        req({ params: { slug: 'invoice' } }), response, next
+      );
+
+      expect(svc.getBySlug).toHaveBeenCalledWith('invoice');
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: tpl })
+      );
+    });
+
+    it('should call next on error', async () => {
+      svc.getBySlug.mockRejectedValue(new Error('not found'));
+
+      await documentTemplateController.getBySlug(
+        req({ params: { slug: 'missing' } }), res(), next
+      );
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // create
+  // ═══════════════════════════════════════════════════════
+  describe('create()', () => {
+    const validBody = {
+      slug: 'new-tpl',
+      name: 'New Template',
+      category: 'RESERVATION_PDF',
+      content: '<html>{{hallName}}</html>',
+    };
+
+    it('should throw 401 when no user (via next)', async () => {
+      await documentTemplateController.create(
+        req({ user: undefined, body: validBody }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 })
+      );
+    });
+
+    it('should throw 400 when slug missing', async () => {
+      await documentTemplateController.create(
+        req({ body: { ...validBody, slug: '' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when name missing', async () => {
+      await documentTemplateController.create(
+        req({ body: { ...validBody, name: '' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when category missing', async () => {
+      await documentTemplateController.create(
+        req({ body: { ...validBody, category: '' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when content missing', async () => {
+      await documentTemplateController.create(
+        req({ body: { ...validBody, content: '' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when content is whitespace only', async () => {
+      await documentTemplateController.create(
+        req({ body: { ...validBody, content: '   ' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should create template and return 201', async () => {
+      const created = { id: 't1', ...validBody };
+      svc.create.mockResolvedValue(created);
+
+      const response = res();
+      await documentTemplateController.create(
+        req({ body: validBody }), response, next
+      );
+
+      expect(response.status).toHaveBeenCalledWith(201);
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: created })
+      );
+      expect(svc.create).toHaveBeenCalledWith(
+        expect.objectContaining({ slug: 'new-tpl', name: 'New Template' }),
+        'user-1'
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // update
+  // ═══════════════════════════════════════════════════════
+  describe('update()', () => {
+    it('should throw 401 when no user', async () => {
+      await documentTemplateController.update(
+        req({ user: undefined, params: { slug: 'tpl' }, body: { content: 'x' } }),
+        res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 })
+      );
+    });
+
+    it('should throw 400 when content missing', async () => {
+      await documentTemplateController.update(
+        req({ params: { slug: 'tpl' }, body: {} }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when content is empty string', async () => {
+      await documentTemplateController.update(
+        req({ params: { slug: 'tpl' }, body: { content: '  ' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should update template on valid input', async () => {
+      const updated = { id: 't1', slug: 'tpl', content: 'new content' };
+      svc.update.mockResolvedValue(updated);
+
+      const response = res();
+      await documentTemplateController.update(
+        req({ params: { slug: 'tpl' }, body: { content: 'new content', changeReason: 'fix typo' } }),
+        response, next
+      );
+
+      expect(svc.update).toHaveBeenCalledWith(
+        'tpl',
+        expect.objectContaining({ content: 'new content', changeReason: 'fix typo' }),
+        'user-1'
+      );
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: updated })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // delete
+  // ═══════════════════════════════════════════════════════
+  describe('delete()', () => {
+    it('should throw 401 when no user', async () => {
+      await documentTemplateController.delete(
+        req({ user: undefined, params: { slug: 'tpl' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 })
+      );
+    });
+
+    it('should delete template and return result', async () => {
+      const result = { deleted: true };
+      svc.delete.mockResolvedValue(result);
+
+      const response = res();
+      await documentTemplateController.delete(
+        req({ params: { slug: 'tpl' } }), response, next
+      );
+
+      expect(svc.delete).toHaveBeenCalledWith('tpl', 'user-1');
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: result })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // restore
+  // ═══════════════════════════════════════════════════════
+  describe('restore()', () => {
+    it('should throw 401 when no user', async () => {
+      await documentTemplateController.restore(
+        req({ user: undefined, params: { slug: 'tpl', version: '2' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 401 })
+      );
+    });
+
+    it('should throw 400 when version is not a positive number', async () => {
+      await documentTemplateController.restore(
+        req({ params: { slug: 'tpl', version: '0' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when version is NaN', async () => {
+      await documentTemplateController.restore(
+        req({ params: { slug: 'tpl', version: 'abc' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should restore version on valid input', async () => {
+      const restored = { id: 't1', slug: 'tpl', version: 2 };
+      svc.restore.mockResolvedValue(restored);
+
+      const response = res();
+      await documentTemplateController.restore(
+        req({ params: { slug: 'tpl', version: '2' } }), response, next
+      );
+
+      expect(svc.restore).toHaveBeenCalledWith('tpl', 2, 'user-1');
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: restored })
+      );
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // preview
+  // ═══════════════════════════════════════════════════════
+  describe('preview()', () => {
+    it('should throw 400 when variables is not an object', async () => {
+      await documentTemplateController.preview(
+        req({ params: { slug: 'tpl' }, body: { variables: 'string' } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should throw 400 when variables is an array', async () => {
+      await documentTemplateController.preview(
+        req({ params: { slug: 'tpl' }, body: { variables: [1, 2] } }), res(), next
+      );
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({ statusCode: 400 })
+      );
+    });
+
+    it('should preview template with default empty variables', async () => {
+      const result = { html: '<p>Hello</p>' };
+      svc.preview.mockResolvedValue(result);
+
+      const response = res();
+      await documentTemplateController.preview(
+        req({ params: { slug: 'tpl' }, body: {} }), response, next
+      );
+
+      expect(svc.preview).toHaveBeenCalledWith('tpl', {});
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: result })
+      );
+    });
+
+    it('should preview template with provided variables', async () => {
+      const vars = { hallName: 'Sala Zlota', eventDate: '2026-06-15' };
+      const result = { html: '<p>Sala Zlota</p>' };
+      svc.preview.mockResolvedValue(result);
+
+      const response = res();
+      await documentTemplateController.preview(
+        req({ params: { slug: 'tpl' }, body: { variables: vars } }), response, next
+      );
+
+      expect(svc.preview).toHaveBeenCalledWith('tpl', vars);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // getHistory
+  // ═══════════════════════════════════════════════════════
+  describe('getHistory()', () => {
+    it('should return paginated history with defaults', async () => {
+      const historyResult = { data: [], total: 0, page: 1, limit: 20 };
+      svc.getHistory.mockResolvedValue(historyResult);
+
+      const response = res();
+      await documentTemplateController.getHistory(
+        req({ params: { slug: 'tpl' }, query: {} }), response, next
+      );
+
+      expect(svc.getHistory).toHaveBeenCalledWith('tpl', 1, 20);
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true })
+      );
+    });
+
+    it('should clamp page to minimum 1', async () => {
+      svc.getHistory.mockResolvedValue({ data: [], total: 0 });
+
+      await documentTemplateController.getHistory(
+        req({ params: { slug: 'tpl' }, query: { page: '-5' } }), res(), next
+      );
+
+      expect(svc.getHistory).toHaveBeenCalledWith('tpl', 1, 20);
+    });
+
+    it('should clamp limit to max 100', async () => {
+      svc.getHistory.mockResolvedValue({ data: [], total: 0 });
+
+      await documentTemplateController.getHistory(
+        req({ params: { slug: 'tpl' }, query: { limit: '500' } }), res(), next
+      );
+
+      expect(svc.getHistory).toHaveBeenCalledWith('tpl', 1, 100);
+    });
+
+    it('should call next on error', async () => {
+      svc.getHistory.mockRejectedValue(new Error('fail'));
+
+      await documentTemplateController.getHistory(
+        req({ params: { slug: 'tpl' } }), res(), next
+      );
+
+      expect(next).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+});

--- a/apps/backend/src/tests/unit/controllers/serviceExtra.controller.test.ts
+++ b/apps/backend/src/tests/unit/controllers/serviceExtra.controller.test.ts
@@ -1,0 +1,497 @@
+/**
+ * ServiceExtraController — Unit Tests
+ *
+ * Covers: Categories CRUD, Items CRUD, Reservation extras management
+ */
+
+jest.mock('../../../services/serviceExtra.service', () => ({
+  __esModule: true,
+  default: {
+    getCategories: jest.fn(),
+    getCategoryById: jest.fn(),
+    createCategory: jest.fn(),
+    updateCategory: jest.fn(),
+    deleteCategory: jest.fn(),
+    reorderCategories: jest.fn(),
+    getItems: jest.fn(),
+    getItemsByCategory: jest.fn(),
+    getItemById: jest.fn(),
+    createItem: jest.fn(),
+    updateItem: jest.fn(),
+    deleteItem: jest.fn(),
+    getReservationExtras: jest.fn(),
+    assignExtra: jest.fn(),
+    bulkAssignExtras: jest.fn(),
+    updateReservationExtra: jest.fn(),
+    removeReservationExtra: jest.fn(),
+  },
+}));
+
+import { ServiceExtraController } from '../../../controllers/serviceExtra.controller';
+import serviceExtraService from '../../../services/serviceExtra.service';
+
+const svc = serviceExtraService as any;
+const controller = new ServiceExtraController();
+
+// ─── Helpers ─────────────────────────────────────────────
+const req = (overrides: any = {}): any => ({
+  body: {},
+  params: {},
+  query: {},
+  user: { id: 'user-1' },
+  ...overrides,
+});
+
+const res = () => {
+  const r: any = {};
+  r.status = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  return r;
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+// ─── Tests ───────────────────────────────────────────────
+describe('ServiceExtraController', () => {
+  // ═══════════════════════════════════════════════════════
+  // CATEGORIES
+  // ═══════════════════════════════════════════════════════
+  describe('getCategories()', () => {
+    it('should return categories with count', async () => {
+      const cats = [{ id: 'c1', name: 'Dekoracje' }];
+      svc.getCategories.mockResolvedValue(cats);
+
+      const response = res();
+      await controller.getCategories(req({ query: {} }), response);
+
+      expect(svc.getCategories).toHaveBeenCalledWith(false);
+      expect(response.status).toHaveBeenCalledWith(200);
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: cats, count: 1 })
+      );
+    });
+
+    it('should pass activeOnly=true when query param set', async () => {
+      svc.getCategories.mockResolvedValue([]);
+
+      await controller.getCategories(req({ query: { activeOnly: 'true' } }), res());
+
+      expect(svc.getCategories).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('getCategoryById()', () => {
+    it('should return single category', async () => {
+      const cat = { id: 'c1', name: 'Dekoracje' };
+      svc.getCategoryById.mockResolvedValue(cat);
+
+      const response = res();
+      await controller.getCategoryById(req({ params: { id: 'c1' } }), response);
+
+      expect(svc.getCategoryById).toHaveBeenCalledWith('c1');
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true, data: cat })
+      );
+    });
+  });
+
+  describe('createCategory()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.createCategory(req({ user: undefined, body: { name: 'X', slug: 'x' } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when name missing', async () => {
+      await expect(
+        controller.createCategory(req({ body: { slug: 'x' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when slug missing', async () => {
+      await expect(
+        controller.createCategory(req({ body: { name: 'X' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should create category and return 201', async () => {
+      const cat = { id: 'c1', name: 'Dekoracje', slug: 'dekoracje' };
+      svc.createCategory.mockResolvedValue(cat);
+
+      const response = res();
+      await controller.createCategory(
+        req({ body: { name: 'Dekoracje', slug: 'dekoracje' } }), response
+      );
+
+      expect(response.status).toHaveBeenCalledWith(201);
+      expect(svc.createCategory).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Dekoracje', slug: 'dekoracje' }),
+        'user-1'
+      );
+    });
+  });
+
+  describe('updateCategory()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.updateCategory(req({ user: undefined, params: { id: 'c1' } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should update category with partial data', async () => {
+      const cat = { id: 'c1', name: 'Dekoracje v2' };
+      svc.updateCategory.mockResolvedValue(cat);
+
+      const response = res();
+      await controller.updateCategory(
+        req({ params: { id: 'c1' }, body: { name: 'Dekoracje v2' } }), response
+      );
+
+      expect(svc.updateCategory).toHaveBeenCalledWith(
+        'c1',
+        expect.objectContaining({ name: 'Dekoracje v2' }),
+        'user-1'
+      );
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('deleteCategory()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.deleteCategory(req({ user: undefined, params: { id: 'c1' } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should delete category', async () => {
+      svc.deleteCategory.mockResolvedValue(undefined);
+
+      const response = res();
+      await controller.deleteCategory(req({ params: { id: 'c1' } }), response);
+
+      expect(svc.deleteCategory).toHaveBeenCalledWith('c1', 'user-1');
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('reorderCategories()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.reorderCategories(req({ user: undefined, body: { orderedIds: ['c1'] } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when orderedIds missing', async () => {
+      await expect(
+        controller.reorderCategories(req({ body: {} }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when orderedIds is not array', async () => {
+      await expect(
+        controller.reorderCategories(req({ body: { orderedIds: 'abc' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should reorder categories', async () => {
+      const cats = [{ id: 'c2' }, { id: 'c1' }];
+      svc.reorderCategories.mockResolvedValue(cats);
+
+      const response = res();
+      await controller.reorderCategories(
+        req({ body: { orderedIds: ['c2', 'c1'] } }), response
+      );
+
+      expect(svc.reorderCategories).toHaveBeenCalledWith(
+        { orderedIds: ['c2', 'c1'] }, 'user-1'
+      );
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // ITEMS
+  // ═══════════════════════════════════════════════════════
+  describe('getItems()', () => {
+    it('should return all items', async () => {
+      const items = [{ id: 'i1' }];
+      svc.getItems.mockResolvedValue(items);
+
+      const response = res();
+      await controller.getItems(req({ query: {} }), response);
+
+      expect(svc.getItems).toHaveBeenCalledWith(false);
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ data: items, count: 1 })
+      );
+    });
+
+    it('should filter by categoryId when provided', async () => {
+      svc.getItemsByCategory.mockResolvedValue([]);
+
+      await controller.getItems(
+        req({ query: { categoryId: 'c1', activeOnly: 'true' } }), res()
+      );
+
+      expect(svc.getItemsByCategory).toHaveBeenCalledWith('c1', true);
+    });
+  });
+
+  describe('getItemById()', () => {
+    it('should return item by id', async () => {
+      const item = { id: 'i1', name: 'DJ' };
+      svc.getItemById.mockResolvedValue(item);
+
+      const response = res();
+      await controller.getItemById(req({ params: { id: 'i1' } }), response);
+
+      expect(svc.getItemById).toHaveBeenCalledWith('i1');
+    });
+  });
+
+  describe('createItem()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.createItem(
+          req({ user: undefined, body: { categoryId: 'c1', name: 'DJ', priceType: 'FIXED' } }),
+          res()
+        )
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when categoryId missing', async () => {
+      await expect(
+        controller.createItem(req({ body: { name: 'DJ', priceType: 'FIXED' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when name missing', async () => {
+      await expect(
+        controller.createItem(req({ body: { categoryId: 'c1', priceType: 'FIXED' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when priceType missing', async () => {
+      await expect(
+        controller.createItem(req({ body: { categoryId: 'c1', name: 'DJ' } }), res())
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should create item and return 201', async () => {
+      const item = { id: 'i1', name: 'DJ', categoryId: 'c1', priceType: 'FIXED' };
+      svc.createItem.mockResolvedValue(item);
+
+      const response = res();
+      await controller.createItem(
+        req({ body: { categoryId: 'c1', name: 'DJ', priceType: 'FIXED', basePrice: 500 } }),
+        response
+      );
+
+      expect(response.status).toHaveBeenCalledWith(201);
+      expect(svc.createItem).toHaveBeenCalledWith(
+        expect.objectContaining({ categoryId: 'c1', name: 'DJ', priceType: 'FIXED', basePrice: 500 }),
+        'user-1'
+      );
+    });
+  });
+
+  describe('updateItem()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.updateItem(req({ user: undefined, params: { id: 'i1' } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should update item with partial data', async () => {
+      svc.updateItem.mockResolvedValue({ id: 'i1', name: 'DJ Pro' });
+
+      const response = res();
+      await controller.updateItem(
+        req({ params: { id: 'i1' }, body: { name: 'DJ Pro', basePrice: 800 } }),
+        response
+      );
+
+      expect(svc.updateItem).toHaveBeenCalledWith(
+        'i1',
+        expect.objectContaining({ name: 'DJ Pro', basePrice: 800 }),
+        'user-1'
+      );
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('deleteItem()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.deleteItem(req({ user: undefined, params: { id: 'i1' } }), res())
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should delete item', async () => {
+      svc.deleteItem.mockResolvedValue(undefined);
+
+      const response = res();
+      await controller.deleteItem(req({ params: { id: 'i1' } }), response);
+
+      expect(svc.deleteItem).toHaveBeenCalledWith('i1', 'user-1');
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════
+  // RESERVATION EXTRAS
+  // ═══════════════════════════════════════════════════════
+  describe('getReservationExtras()', () => {
+    it('should return extras for reservation', async () => {
+      const result = { extras: [{ id: 'e1' }], totalExtrasPrice: 100, count: 1 };
+      svc.getReservationExtras.mockResolvedValue(result);
+
+      const response = res();
+      await controller.getReservationExtras(
+        req({ params: { reservationId: 'r1' } }), response
+      );
+
+      expect(svc.getReservationExtras).toHaveBeenCalledWith('r1');
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: result.extras,
+          totalExtrasPrice: 100,
+          count: 1,
+        })
+      );
+    });
+  });
+
+  describe('assignExtra()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.assignExtra(
+          req({ user: undefined, params: { reservationId: 'r1' }, body: { serviceItemId: 'i1' } }),
+          res()
+        )
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when serviceItemId missing', async () => {
+      await expect(
+        controller.assignExtra(
+          req({ params: { reservationId: 'r1' }, body: {} }), res()
+        )
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should assign extra and return 201', async () => {
+      const extra = { id: 'e1', serviceItemId: 'i1' };
+      svc.assignExtra.mockResolvedValue(extra);
+
+      const response = res();
+      await controller.assignExtra(
+        req({ params: { reservationId: 'r1' }, body: { serviceItemId: 'i1', quantity: 2 } }),
+        response
+      );
+
+      expect(response.status).toHaveBeenCalledWith(201);
+      expect(svc.assignExtra).toHaveBeenCalledWith(
+        'r1',
+        expect.objectContaining({ serviceItemId: 'i1', quantity: 2 }),
+        'user-1'
+      );
+    });
+  });
+
+  describe('bulkAssignExtras()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.bulkAssignExtras(
+          req({ user: undefined, params: { reservationId: 'r1' }, body: { extras: [] } }),
+          res()
+        )
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should throw 400 when extras missing', async () => {
+      await expect(
+        controller.bulkAssignExtras(
+          req({ params: { reservationId: 'r1' }, body: {} }), res()
+        )
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should throw 400 when extras is not array', async () => {
+      await expect(
+        controller.bulkAssignExtras(
+          req({ params: { reservationId: 'r1' }, body: { extras: 'not-array' } }), res()
+        )
+      ).rejects.toMatchObject({ statusCode: 400 });
+    });
+
+    it('should bulk assign extras', async () => {
+      const result = { extras: [], totalExtrasPrice: 0, count: 0 };
+      svc.bulkAssignExtras.mockResolvedValue(result);
+
+      const response = res();
+      await controller.bulkAssignExtras(
+        req({ params: { reservationId: 'r1' }, body: { extras: [{ serviceItemId: 'i1' }] } }),
+        response
+      );
+
+      expect(response.status).toHaveBeenCalledWith(200);
+      expect(svc.bulkAssignExtras).toHaveBeenCalledWith(
+        'r1', { extras: [{ serviceItemId: 'i1' }] }, 'user-1'
+      );
+    });
+  });
+
+  describe('updateReservationExtra()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.updateReservationExtra(
+          req({ user: undefined, params: { reservationId: 'r1', extraId: 'e1' } }), res()
+        )
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should update reservation extra with partial data', async () => {
+      const extra = { id: 'e1', quantity: 5 };
+      svc.updateReservationExtra.mockResolvedValue(extra);
+
+      const response = res();
+      await controller.updateReservationExtra(
+        req({
+          params: { reservationId: 'r1', extraId: 'e1' },
+          body: { quantity: 5, note: 'VIP' },
+        }),
+        response
+      );
+
+      expect(svc.updateReservationExtra).toHaveBeenCalledWith(
+        'r1', 'e1',
+        expect.objectContaining({ quantity: 5, note: 'VIP' }),
+        'user-1'
+      );
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+
+  describe('removeReservationExtra()', () => {
+    it('should throw 401 when no user', async () => {
+      await expect(
+        controller.removeReservationExtra(
+          req({ user: undefined, params: { reservationId: 'r1', extraId: 'e1' } }), res()
+        )
+      ).rejects.toMatchObject({ statusCode: 401 });
+    });
+
+    it('should remove reservation extra', async () => {
+      svc.removeReservationExtra.mockResolvedValue(undefined);
+
+      const response = res();
+      await controller.removeReservationExtra(
+        req({ params: { reservationId: 'r1', extraId: 'e1' } }), response
+      );
+
+      expect(svc.removeReservationExtra).toHaveBeenCalledWith('r1', 'e1', 'user-1');
+      expect(response.status).toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/apps/backend/src/tests/unit/middlewares/validateBody.test.ts
+++ b/apps/backend/src/tests/unit/middlewares/validateBody.test.ts
@@ -1,0 +1,136 @@
+/**
+ * validateBody middleware — Unit Tests
+ *
+ * Covers: success path (body replacement + next), validation failure (400 + errors list)
+ */
+
+import { Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { validateBody } from '../../../middlewares/validateBody';
+
+// ─── Helpers ─────────────────────────────────────────────
+const mockReq = (body: any = {}): Partial<Request> => ({ body });
+
+const mockRes = () => {
+  const r: any = {};
+  r.status = jest.fn().mockReturnValue(r);
+  r.json = jest.fn().mockReturnValue(r);
+  return r as Response;
+};
+
+const mockNext = jest.fn() as jest.MockedFunction<NextFunction>;
+
+beforeEach(() => jest.clearAllMocks());
+
+// ─── Tests ───────────────────────────────────────────────
+describe('validateBody', () => {
+  const schema = z.object({
+    name: z.string().min(1, 'Nazwa jest wymagana'),
+    age: z.number().min(0, 'Wiek musi byc >= 0'),
+  });
+
+  describe('valid body', () => {
+    it('should call next() and replace req.body with parsed data', () => {
+      const req = mockReq({ name: 'Jan', age: 25 });
+      const res = mockRes();
+      const middleware = validateBody(schema);
+
+      middleware(req as Request, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(req.body).toEqual({ name: 'Jan', age: 25 });
+    });
+
+    it('should strip unknown fields from body', () => {
+      const req = mockReq({ name: 'Jan', age: 30, unknown: 'field' });
+      const res = mockRes();
+      const middleware = validateBody(schema);
+
+      middleware(req as Request, res, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(req.body).toEqual({ name: 'Jan', age: 30 });
+      expect(req.body.unknown).toBeUndefined();
+    });
+  });
+
+  describe('invalid body', () => {
+    it('should return 400 with error details when body is empty', () => {
+      const req = mockReq({});
+      const response = mockRes();
+      const middleware = validateBody(schema);
+
+      middleware(req as Request, response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(response.status).toHaveBeenCalledWith(400);
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          error: expect.any(String),
+          details: expect.arrayContaining([
+            expect.objectContaining({ field: expect.any(String), message: expect.any(String) }),
+          ]),
+        })
+      );
+    });
+
+    it('should return field path in error details', () => {
+      const req = mockReq({ name: '', age: -1 });
+      const response = mockRes();
+      const middleware = validateBody(schema);
+
+      middleware(req as Request, response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const jsonCall = (response.json as jest.Mock).mock.calls[0][0];
+      const fields = jsonCall.details.map((d: any) => d.field);
+      expect(fields).toEqual(expect.arrayContaining(['name']));
+    });
+
+    it('should return 400 when wrong type provided', () => {
+      const req = mockReq({ name: 123, age: 'not-a-number' });
+      const response = mockRes();
+      const middleware = validateBody(schema);
+
+      middleware(req as Request, response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(response.status).toHaveBeenCalledWith(400);
+    });
+  });
+
+  describe('nested schema', () => {
+    const nestedSchema = z.object({
+      address: z.object({
+        street: z.string().min(1),
+        city: z.string().min(1),
+      }),
+    });
+
+    it('should validate nested objects and return dotted field paths', () => {
+      const req = mockReq({ address: { street: '', city: '' } });
+      const response = mockRes();
+      const middleware = validateBody(nestedSchema);
+
+      middleware(req as Request, response, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      const jsonCall = (response.json as jest.Mock).mock.calls[0][0];
+      const fields = jsonCall.details.map((d: any) => d.field);
+      expect(fields).toContain('address.street');
+      expect(fields).toContain('address.city');
+    });
+
+    it('should pass valid nested object', () => {
+      const req = mockReq({ address: { street: 'ul. Testowa 1', city: 'Warszawa' } });
+      const response = mockRes();
+      const middleware = validateBody(nestedSchema);
+
+      middleware(req as Request, response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Dodaje unit testy dla **ArchiveAdminController** (getArchiveSettings, updateArchiveSettings, runArchiveNow) — walidacja auth, input, happy path
- Dodaje unit testy dla **DocumentTemplateController** (list, getBySlug, create, update, delete, restore, preview, getHistory) — walidacja auth, input, error forwarding via next()
- Dodaje unit testy dla **ServiceExtraController** (Categories CRUD, Items CRUD, Reservation extras) — walidacja auth, input, service delegation
- Dodaje unit testy dla **validateBody middleware** (Zod schema validation, nested objects, dotted field paths, unknown field stripping)

## Nowe pliki
- `apps/backend/src/tests/unit/controllers/archive-admin.controller.test.ts`
- `apps/backend/src/tests/unit/controllers/document-template.controller.test.ts`
- `apps/backend/src/tests/unit/controllers/serviceExtra.controller.test.ts`
- `apps/backend/src/tests/unit/middlewares/validateBody.test.ts`

## Test plan
- [ ] CI unit testy przechodzą (`npm run test:unit`)
- [ ] Brak regresji w istniejących testach
- [ ] Coverage controllerów i middlewares wzrasta

🤖 Generated with [Claude Code](https://claude.com/claude-code)