### PR TITLE
feat(tests): testy jednostkowe dla 8 kluczowych stron Next.js

### DIFF
--- a/apps/frontend/__tests__/pages/AuditLogPage.test.tsx
+++ b/apps/frontend/__tests__/pages/AuditLogPage.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Audit Log Page Tests
+ *
+ * Tests the audit log page (/dashboard/audit-log):
+ * - Renders page hero with title
+ * - Stat cards with audit statistics
+ * - Filter button present
+ * - Audit log table rendering
+ * - Loading state
+ * - Empty state when no logs
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUseAuditLogs, mockUseAuditLogStatistics } = vi.hoisted(() => ({
+  mockUseAuditLogs: vi.fn(),
+  mockUseAuditLogStatistics: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/audit-log',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/hooks/use-audit-log', () => ({
+  useAuditLogs: mockUseAuditLogs,
+  useAuditLogStatistics: mockUseAuditLogStatistics,
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    auditLog: {
+      iconBg: 'bg-zinc-500',
+      text: 'text-zinc-600',
+      textDark: 'text-zinc-400',
+      gradient: 'from-zinc-500 to-neutral-500',
+      gradientSubtle: 'from-zinc-50 to-neutral-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+  LoadingState: ({ message }: any) => <div data-testid="loading-state">{message}</div>,
+  EmptyState: ({ title, description }: any) => (
+    <div data-testid="empty-state">
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/audit-log/AuditLogFilters', () => ({
+  AuditLogFilters: () => <div data-testid="audit-filters">Filtry</div>,
+}))
+
+vi.mock('@/components/audit-log/AuditLogTable', () => ({
+  AuditLogTable: ({ data }: any) => (
+    <div data-testid="audit-table">
+      {data.map((item: any) => <div key={item.id}>{item.action}</div>)}
+    </div>
+  ),
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import AuditLogPage from '@/app/dashboard/audit-log/page'
+
+// ── Test Data ────────────────────────────────────────────────────────────────
+
+const mockStats = {
+  totalLogs: 150,
+  byAction: [{ action: 'CREATE', count: 50 }],
+  byEntityType: [{ entityType: 'RESERVATION', count: 80 }],
+  byUser: [{ userId: 'u1', count: 40 }],
+}
+
+const mockLogsData = {
+  data: [
+    { id: 'log-1', action: 'CREATE', entityType: 'RESERVATION', createdAt: '2026-03-15T10:00:00Z' },
+    { id: 'log-2', action: 'UPDATE', entityType: 'CLIENT', createdAt: '2026-03-15T11:00:00Z' },
+  ],
+  total: 2,
+  totalPages: 1,
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AuditLogPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page hero with title', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByText('Dziennik Audytu')).toBeInTheDocument()
+  })
+
+  it('renders subtitle', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByText('Historia wszystkich zmian w systemie')).toBeInTheDocument()
+  })
+
+  it('renders stat cards when stats loaded', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByTestId('stat-Wszystkie wpisy')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-Najczęstsza akcja')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-Najczęstszy typ')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-Aktywni użytkownicy')).toBeInTheDocument()
+  })
+
+  it('renders filter button', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByText('Filtry')).toBeInTheDocument()
+  })
+
+  it('renders audit log table with data', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByTestId('audit-table')).toBeInTheDocument()
+  })
+
+  it('renders "Historia zmian" card title', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByText('Historia zmian')).toBeInTheDocument()
+  })
+
+  it('shows total count in subtitle', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByText('2 wpisy')).toBeInTheDocument()
+  })
+
+  it('shows loading state when logs are loading', () => {
+    mockUseAuditLogs.mockReturnValue({ data: undefined, isLoading: true })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no logs', () => {
+    mockUseAuditLogs.mockReturnValue({ data: { data: [], total: 0, totalPages: 0 }, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: mockStats, isLoading: false })
+
+    render(<AuditLogPage />)
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+    expect(screen.getByText('Brak wpisów w dzienniku')).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton for stats when stats loading', () => {
+    mockUseAuditLogs.mockReturnValue({ data: mockLogsData, isLoading: false })
+    mockUseAuditLogStatistics.mockReturnValue({ data: undefined, isLoading: true })
+
+    render(<AuditLogPage />)
+    // Should show 4 skeleton cards
+    const loadingStates = screen.getAllByTestId('loading-state')
+    expect(loadingStates.length).toBe(4)
+  })
+})

--- a/apps/frontend/__tests__/pages/ClientsPage.test.tsx
+++ b/apps/frontend/__tests__/pages/ClientsPage.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Clients Page Tests
+ *
+ * Tests the clients page (/dashboard/clients):
+ * - Renders page hero with title
+ * - Stat cards display
+ * - Search input present
+ * - "Add client" button
+ * - Filter tabs (All / Individual / Company)
+ * - Show/hide deleted toggle
+ * - Loading state
+ * - Client list rendering
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockClientsGetAll } = vi.hoisted(() => ({
+  mockClientsGetAll: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/clients',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api/clients', () => ({
+  clientsApi: { getAll: mockClientsGetAll },
+  clientsKeys: { list: (params: any) => ['clients', params] },
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    clients: {
+      iconBg: 'bg-violet-500',
+      text: 'text-violet-600',
+      textDark: 'text-violet-400',
+      gradient: 'from-violet-500 to-purple-500',
+      gradientSubtle: 'from-violet-50 to-purple-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageHero: ({ title, subtitle, action }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {action}
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+  LoadingState: ({ message }: any) => <div data-testid="loading-state">{message}</div>,
+}))
+
+vi.mock('@/components/shared/FilterTabs', () => ({
+  FilterTabs: ({ tabs, activeKey, onChange }: any) => (
+    <div data-testid="filter-tabs">
+      {tabs.map((tab: any) => (
+        <button key={tab.key} onClick={() => onChange(tab.key)} data-active={tab.key === activeKey}>
+          {tab.label} ({tab.count})
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+vi.mock('@/components/clients/clients-list', () => ({
+  ClientsList: ({ clients }: any) => (
+    <div data-testid="clients-list">
+      {clients.map((c: any) => <div key={c.id}>{c.firstName} {c.lastName}</div>)}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/clients/create-client-form', () => ({
+  CreateClientForm: () => <div data-testid="create-client-form">Formularz klienta</div>,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import ClientsPage from '@/app/dashboard/clients/page'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockClients = [
+  { id: 'c-1', firstName: 'Jan', lastName: 'Kowalski', clientType: 'INDIVIDUAL', _count: { reservations: 3 } },
+  { id: 'c-2', firstName: 'Anna', lastName: 'Nowak', clientType: 'INDIVIDUAL', _count: { reservations: 1 } },
+  { id: 'c-3', firstName: 'Firma', lastName: 'Sp.', clientType: 'COMPANY', _count: { reservations: 5 } },
+]
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  )
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ClientsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClientsGetAll.mockResolvedValue(mockClients)
+  })
+
+  it('renders page hero with title', () => {
+    renderWithProviders(<ClientsPage />)
+    expect(screen.getByText('Klienci')).toBeInTheDocument()
+  })
+
+  it('renders subtitle', () => {
+    renderWithProviders(<ClientsPage />)
+    expect(screen.getByText('Zarządzaj bazą klientów')).toBeInTheDocument()
+  })
+
+  it('renders "Add client" button', () => {
+    renderWithProviders(<ClientsPage />)
+    expect(screen.getByText('Dodaj klienta')).toBeInTheDocument()
+  })
+
+  it('renders stat cards', async () => {
+    renderWithProviders(<ClientsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-Wszyscy')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Osoby prywatne')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Firmy')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Rezerwacje')).toBeInTheDocument()
+    })
+  })
+
+  it('renders search input', async () => {
+    renderWithProviders(<ClientsPage />)
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/szukaj/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders filter tabs', async () => {
+    renderWithProviders(<ClientsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-tabs')).toBeInTheDocument()
+    })
+  })
+
+  it('renders show/hide deleted button', async () => {
+    renderWithProviders(<ClientsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/pokaż usuniętych/i)).toBeInTheDocument()
+    })
+  })
+
+  it('renders clients list with data', async () => {
+    renderWithProviders(<ClientsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('clients-list')).toBeInTheDocument()
+    })
+  })
+
+  it('displays loading state initially', () => {
+    mockClientsGetAll.mockReturnValue(new Promise(() => {})) // never resolves
+    renderWithProviders(<ClientsPage />)
+    // The loading state should show while query is pending
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/__tests__/pages/DashboardPage.test.tsx
+++ b/apps/frontend/__tests__/pages/DashboardPage.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Dashboard Page Tests
+ *
+ * Tests the main dashboard page (/dashboard):
+ * - Renders page hero with title
+ * - Displays stat cards when data loaded
+ * - Shows loading skeleton state
+ * - Shows error state when API fails
+ * - Renders upcoming events section
+ * - Refresh button present
+ */
+
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUseDashboardOverview, mockUseDashboardUpcoming } = vi.hoisted(() => ({
+  mockUseDashboardOverview: vi.fn(),
+  mockUseDashboardUpcoming: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api/stats-api', () => ({
+  useDashboardOverview: mockUseDashboardOverview,
+  useDashboardUpcoming: mockUseDashboardUpcoming,
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    dashboard: {
+      iconBg: 'bg-indigo-500',
+      text: 'text-indigo-600',
+      textDark: 'text-indigo-400',
+      gradient: 'from-indigo-500 to-blue-500',
+      gradientSubtle: 'from-indigo-50 to-blue-50',
+    },
+  },
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_, tag) => ({ children, ...props }: any) => {
+      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+      return <div {...rest}>{children}</div>
+    },
+  }),
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle, action }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {action}
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import DashboardPage from '@/app/dashboard/page'
+
+// ── Test Data ────────────────────────────────────────────────────────────────
+
+const mockOverviewData = {
+  reservationsToday: 3,
+  reservationsThisWeek: 12,
+  queueCount: 5,
+  reservationsThisMonth: 45,
+  confirmedThisMonth: 30,
+  revenueThisMonth: 120000,
+  revenueChangePercent: 15,
+  totalClients: 200,
+  newClientsThisMonth: 10,
+  pendingDepositsCount: 4,
+  pendingDepositsAmount: 15000,
+}
+
+const mockUpcomingData = [
+  {
+    id: 'res-1',
+    date: '2026-04-15',
+    status: 'CONFIRMED',
+    startTime: '14:00',
+    guests: 120,
+    totalPrice: '25000',
+    client: { firstName: 'Jan', lastName: 'Kowalski' },
+    eventType: { name: 'Wesele' },
+    hall: { name: 'Sala Główna' },
+    deposits: [],
+  },
+]
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page hero with title', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: mockUpcomingData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText('Panel Główny')).toBeInTheDocument()
+  })
+
+  it('renders stat cards with data', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: mockUpcomingData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByTestId('stat-Rezerwacje Dziś')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-W Kolejce')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-Potwierdzone')).toBeInTheDocument()
+    expect(screen.getByTestId('stat-Klienci')).toBeInTheDocument()
+  })
+
+  it('renders refresh button', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: mockUpcomingData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText('Odśwież')).toBeInTheDocument()
+  })
+
+  it('shows loading text when data is loading', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText('Ładowanie...')).toBeInTheDocument()
+  })
+
+  it('shows error message when overview API fails', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('API error'),
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText('Nie udało się pobrać statystyk')).toBeInTheDocument()
+    expect(screen.getByText('Spróbuj ponownie')).toBeInTheDocument()
+  })
+
+  it('renders upcoming events section heading', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: mockUpcomingData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText(/Najbliższe Wydarzenia/)).toBeInTheDocument()
+  })
+
+  it('renders link to all reservations', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: mockUpcomingData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    const link = screen.getByText('Zobacz wszystkie')
+    expect(link.closest('a')).toHaveAttribute('href', '/dashboard/reservations')
+  })
+
+  it('renders empty state when no upcoming events', () => {
+    mockUseDashboardOverview.mockReturnValue({
+      data: mockOverviewData,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+    mockUseDashboardUpcoming.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    })
+
+    render(<DashboardPage />)
+    expect(screen.getByText('Brak nadchodzących wydarzeń')).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/__tests__/pages/DepositsPage.test.tsx
+++ b/apps/frontend/__tests__/pages/DepositsPage.test.tsx
@@ -1,0 +1,273 @@
+/**
+ * Deposits Page Tests
+ *
+ * Tests the deposits page (/dashboard/deposits):
+ * - Renders page hero with title
+ * - Stat cards with deposit statistics
+ * - "New Deposit" button
+ * - Search input
+ * - Filter tabs (All, Pending, Paid, Overdue, Cancelled)
+ * - Deposits list rendering
+ * - Loading state
+ * - Empty state
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockDepositsGetAll, mockDepositsGetStats } = vi.hoisted(() => ({
+  mockDepositsGetAll: vi.fn(),
+  mockDepositsGetStats: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/deposits',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api/deposits', () => ({
+  depositsApi: {
+    getAll: mockDepositsGetAll,
+    getStats: mockDepositsGetStats,
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    deposits: {
+      iconBg: 'bg-rose-500',
+      text: 'text-rose-600',
+      textDark: 'text-rose-400',
+      gradient: 'from-rose-500 to-pink-500',
+      gradientSubtle: 'from-rose-50 to-pink-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle, action }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {action}
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+  LoadingState: ({ message }: any) => <div data-testid="loading-state">{message}</div>,
+  EmptyState: ({ title, description, actionLabel, onAction }: any) => (
+    <div data-testid="empty-state">
+      <h3>{title}</h3>
+      <p>{description}</p>
+      {actionLabel && <button onClick={onAction}>{actionLabel}</button>}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/shared/FilterTabs', () => ({
+  FilterTabs: ({ tabs, activeKey, onChange }: any) => (
+    <div data-testid="filter-tabs">
+      {tabs.map((tab: any) => (
+        <button key={tab.key} onClick={() => onChange(tab.key)} data-active={tab.key === activeKey}>
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardHeader: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: any) => <input {...props} />,
+}))
+
+vi.mock('@/components/deposits/deposits-list', () => ({
+  DepositsList: ({ deposits }: any) => (
+    <div data-testid="deposits-list">
+      {deposits.map((d: any) => <div key={d.id}>{d.title}</div>)}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/deposits/create-deposit-form', () => ({
+  CreateDepositForm: () => <div data-testid="create-deposit-form">Formularz zaliczki</div>,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import DepositsPage from '@/app/dashboard/deposits/page'
+
+// ── Test Data ────────────────────────────────────────────────────────────────
+
+const mockStats = {
+  counts: { total: 10, pending: 4, paid: 3, overdue: 2, cancelled: 1 },
+  amounts: { total: 50000, pending: 20000, paid: 25000, overdue: 5000 },
+}
+
+const mockDeposits = [
+  {
+    id: 'dep-1',
+    title: 'Zaliczka wesele',
+    amount: 5000,
+    status: 'PENDING',
+    reservation: {
+      client: { firstName: 'Jan', lastName: 'Kowalski' },
+      hall: { name: 'Sala Główna' },
+      eventType: { name: 'Wesele' },
+    },
+  },
+  {
+    id: 'dep-2',
+    title: 'Zaliczka komunia',
+    amount: 2000,
+    status: 'PAID',
+    reservation: {
+      client: { firstName: 'Anna', lastName: 'Nowak' },
+      hall: { name: 'Sala Kameralna' },
+      eventType: { name: 'Komunia' },
+    },
+  },
+]
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('DepositsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page hero with title', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    expect(screen.getByText('Zaliczki')).toBeInTheDocument()
+  })
+
+  it('renders subtitle', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    expect(screen.getByText('Zarządzaj zaliczkami i płatnościami')).toBeInTheDocument()
+  })
+
+  it('renders "New Deposit" button', () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    expect(screen.getByText('Nowa Zaliczka')).toBeInTheDocument()
+  })
+
+  it('renders stat cards after data loads', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-Oczekujące')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Opłacone')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Przetermin.')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Łącznie')).toBeInTheDocument()
+    })
+  })
+
+  it('renders filter tabs', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('filter-tabs')).toBeInTheDocument()
+      expect(screen.getByText('Wszystkie')).toBeInTheDocument()
+      expect(screen.getByText('Opłacone')).toBeInTheDocument()
+    })
+  })
+
+  it('renders search input', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Szukaj...')).toBeInTheDocument()
+    })
+  })
+
+  it('renders deposits list with data', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('deposits-list')).toBeInTheDocument()
+    })
+  })
+
+  it('renders "Lista Zaliczek" card title', async () => {
+    mockDepositsGetAll.mockResolvedValue(mockDeposits)
+    mockDepositsGetStats.mockResolvedValue(mockStats)
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Lista Zaliczek')).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading state initially', () => {
+    mockDepositsGetAll.mockReturnValue(new Promise(() => {}))
+    mockDepositsGetStats.mockReturnValue(new Promise(() => {}))
+
+    render(<DepositsPage />)
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no deposits and no filters', async () => {
+    mockDepositsGetAll.mockResolvedValue([])
+    mockDepositsGetStats.mockResolvedValue({
+      counts: { total: 0, pending: 0, paid: 0, overdue: 0, cancelled: 0 },
+      amounts: { total: 0, pending: 0, paid: 0, overdue: 0 },
+    })
+
+    render(<DepositsPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+      expect(screen.getByText('Brak zaliczek')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/__tests__/pages/ForgotPasswordPage.test.tsx
+++ b/apps/frontend/__tests__/pages/ForgotPasswordPage.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Forgot Password Page Tests
+ *
+ * Tests the forgot password page (/forgot-password):
+ * - Renders form with email field
+ * - Shows heading and description
+ * - Back to login link
+ * - Validation for empty email
+ * - Validation for invalid email format
+ * - Success state after submission
+ * - Error state on API failure
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockPost } = vi.hoisted(() => ({
+  mockPost: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/forgot-password',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { post: mockPost },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_, tag) => ({ children, ...props }: any) => {
+      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+      return <div {...rest}>{children}</div>
+    },
+  }),
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import ForgotPasswordPage from '@/app/forgot-password/page'
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ForgotPasswordPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page heading', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByText('Resetuj hasło')).toBeInTheDocument()
+  })
+
+  it('renders branding', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByText('Gościniec Rodzinny')).toBeInTheDocument()
+  })
+
+  it('renders email input', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByLabelText('Adres email')).toBeInTheDocument()
+  })
+
+  it('renders submit button', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByText('Wyślij link resetujący')).toBeInTheDocument()
+  })
+
+  it('renders back to login link', () => {
+    render(<ForgotPasswordPage />)
+    const link = screen.getByText('Wróć do logowania')
+    expect(link).toBeInTheDocument()
+    expect(link.closest('a')).toHaveAttribute('href', '/login')
+  })
+
+  it('shows error for empty email on submit', async () => {
+    render(<ForgotPasswordPage />)
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Adres email jest wymagany')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for invalid email format', async () => {
+    render(<ForgotPasswordPage />)
+    await userEvent.type(screen.getByLabelText('Adres email'), 'not-an-email')
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Nieprawidłowy format adresu email')).toBeInTheDocument()
+    })
+  })
+
+  it('shows success state after valid submission', async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } })
+
+    render(<ForgotPasswordPage />)
+    await userEvent.type(screen.getByLabelText('Adres email'), 'user@example.pl')
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Sprawdź swoją skrzynkę')).toBeInTheDocument()
+    })
+  })
+
+  it('calls API with correct email', async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } })
+
+    render(<ForgotPasswordPage />)
+    await userEvent.type(screen.getByLabelText('Adres email'), 'user@example.pl')
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/auth/forgot-password', { email: 'user@example.pl' })
+    })
+  })
+
+  it('shows return to login link in success state', async () => {
+    mockPost.mockResolvedValueOnce({ data: { success: true } })
+
+    render(<ForgotPasswordPage />)
+    await userEvent.type(screen.getByLabelText('Adres email'), 'user@example.pl')
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      const link = screen.getByText('Wróć do logowania')
+      expect(link.closest('a')).toHaveAttribute('href', '/login')
+    })
+  })
+
+  it('shows error on API failure', async () => {
+    mockPost.mockRejectedValueOnce({
+      response: { data: { error: 'Wystąpił błąd. Spróbuj ponownie.' } },
+    })
+
+    render(<ForgotPasswordPage />)
+    await userEvent.type(screen.getByLabelText('Adres email'), 'user@example.pl')
+    fireEvent.click(screen.getByRole('button', { name: /wyślij/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Wystąpił błąd. Spróbuj ponownie.')).toBeInTheDocument()
+    })
+  })
+
+  it('renders copyright footer', () => {
+    render(<ForgotPasswordPage />)
+    expect(screen.getByText(/2026 Gościniec Rodzinny/)).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/__tests__/pages/LoginPage.test.tsx
+++ b/apps/frontend/__tests__/pages/LoginPage.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Login Page Tests
+ *
+ * Tests the login page (/login):
+ * - Renders login form with email and password fields
+ * - Displays page heading and branding
+ * - Shows forgot password link
+ * - Submit button present and clickable
+ * - Validation error messages for empty fields
+ * - API error display after failed login
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockPush, mockPost } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockPost: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/login',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: { post: mockPost },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('framer-motion', () => ({
+  motion: new Proxy({}, {
+    get: (_, tag) => ({ children, ...props }: any) => {
+      const Tag = typeof tag === 'string' ? tag : 'div'
+      // Filter out framer-motion specific props
+      const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props
+      return <Tag {...rest}>{children}</Tag>
+    },
+  }),
+  AnimatePresence: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import LoginPage from '@/app/login/page'
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Mock localStorage
+    Object.defineProperty(window, 'localStorage', {
+      value: { setItem: vi.fn(), getItem: vi.fn(), removeItem: vi.fn() },
+      writable: true,
+    })
+  })
+
+  it('renders login form heading', () => {
+    render(<LoginPage />)
+    expect(screen.getByText('Zaloguj się')).toBeInTheDocument()
+  })
+
+  it('renders branding text', () => {
+    render(<LoginPage />)
+    expect(screen.getByText('Gościniec Rodzinny')).toBeInTheDocument()
+    expect(screen.getByText('System zarządzania rezerwacjami')).toBeInTheDocument()
+  })
+
+  it('renders email and password inputs', () => {
+    render(<LoginPage />)
+    expect(screen.getByLabelText('Adres email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Hasło')).toBeInTheDocument()
+  })
+
+  it('renders submit button', () => {
+    render(<LoginPage />)
+    const buttons = screen.getAllByText('Zaloguj się')
+    // One is the heading h2, one is the button text
+    expect(buttons.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders forgot password link', () => {
+    render(<LoginPage />)
+    const link = screen.getByText('Nie pamiętam hasła')
+    expect(link).toBeInTheDocument()
+    expect(link.closest('a')).toHaveAttribute('href', '/forgot-password')
+  })
+
+  it('shows validation errors for empty fields on submit', async () => {
+    render(<LoginPage />)
+    const submitButton = screen.getByRole('button', { name: /zaloguj/i })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('Email jest wymagany')).toBeInTheDocument()
+      expect(screen.getByText('Hasło jest wymagane')).toBeInTheDocument()
+    })
+  })
+
+  it('calls API on valid form submission', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { success: true, data: { token: 'test-token', refreshToken: 'refresh-token' } },
+    })
+
+    render(<LoginPage />)
+
+    const emailInput = screen.getByLabelText('Adres email')
+    const passwordInput = screen.getByLabelText('Hasło')
+
+    await userEvent.type(emailInput, 'test@example.pl')
+    await userEvent.type(passwordInput, 'password123')
+
+    const submitButton = screen.getByRole('button', { name: /zaloguj/i })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockPost).toHaveBeenCalledWith('/auth/login', {
+        email: 'test@example.pl',
+        password: 'password123',
+      })
+    })
+  })
+
+  it('redirects to dashboard on successful login', async () => {
+    mockPost.mockResolvedValueOnce({
+      data: { success: true, data: { token: 'test-token', refreshToken: 'refresh-token' } },
+    })
+
+    render(<LoginPage />)
+
+    await userEvent.type(screen.getByLabelText('Adres email'), 'test@example.pl')
+    await userEvent.type(screen.getByLabelText('Hasło'), 'password123')
+    fireEvent.click(screen.getByRole('button', { name: /zaloguj/i }))
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/dashboard')
+    })
+  })
+
+  it('shows error message on failed login', async () => {
+    mockPost.mockRejectedValueOnce({
+      response: { data: { error: 'Niepoprawny email lub hasło' } },
+    })
+
+    render(<LoginPage />)
+
+    await userEvent.type(screen.getByLabelText('Adres email'), 'wrong@test.pl')
+    await userEvent.type(screen.getByLabelText('Hasło'), 'wrongpass')
+    fireEvent.click(screen.getByRole('button', { name: /zaloguj/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Błąd logowania')).toBeInTheDocument()
+      expect(screen.getByText('Niepoprawny email lub hasło')).toBeInTheDocument()
+    })
+  })
+
+  it('renders copyright footer', () => {
+    render(<LoginPage />)
+    expect(screen.getByText(/2026 Gościniec Rodzinny/)).toBeInTheDocument()
+  })
+})

--- a/apps/frontend/__tests__/pages/QueuePage.test.tsx
+++ b/apps/frontend/__tests__/pages/QueuePage.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * Queue Page Tests
+ *
+ * Tests the queue page (/dashboard/queue):
+ * - Renders page hero with title
+ * - Stat cards display with queue data
+ * - "Add to queue" button
+ * - "Rebuild" button
+ * - Date tabs rendering
+ * - Loading state
+ * - Empty state when no queue items
+ * - Queue list rendering
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockQueueGetAll, mockQueueGetStats, mockClientsGetAll } = vi.hoisted(() => ({
+  mockQueueGetAll: vi.fn(),
+  mockQueueGetStats: vi.fn(),
+  mockClientsGetAll: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/queue',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api/queue', () => ({
+  queueApi: {
+    getAll: mockQueueGetAll,
+    getStats: mockQueueGetStats,
+    addToQueue: vi.fn(),
+    updateQueueReservation: vi.fn(),
+    batchUpdatePositions: vi.fn(),
+    rebuildPositions: vi.fn(),
+    promoteReservation: vi.fn(),
+  },
+}))
+
+vi.mock('@/lib/api/clients', () => ({
+  clientsApi: { getAll: mockClientsGetAll },
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('date-fns', () => ({
+  format: (date: any, fmt: string) => '15 Mar 2026',
+  parseISO: (str: string) => new Date(str),
+}))
+
+vi.mock('date-fns/locale', () => ({
+  pl: {},
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    queue: {
+      iconBg: 'bg-amber-500',
+      text: 'text-amber-600',
+      textDark: 'text-amber-400',
+      gradient: 'from-amber-500 to-orange-500',
+      gradientSubtle: 'from-amber-50 to-orange-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle, action }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {action}
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+  LoadingState: ({ message }: any) => <div data-testid="loading-state">{message}</div>,
+  EmptyState: ({ title, description }: any) => (
+    <div data-testid="empty-state">
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: any) => open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h2>{children}</h2>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/alert', () => ({
+  Alert: ({ children }: any) => <div>{children}</div>,
+  AlertDescription: ({ children }: any) => <p>{children}</p>,
+}))
+
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: (props: any) => <input type="checkbox" {...props} />,
+}))
+
+vi.mock('@/components/queue/draggable-queue-list', () => ({
+  DraggableQueueList: ({ items }: any) => (
+    <div data-testid="queue-list">
+      {items.map((item: any) => <div key={item.id}>{item.id}</div>)}
+    </div>
+  ),
+}))
+
+vi.mock('@/components/queue/add-to-queue-form', () => ({
+  AddToQueueForm: () => <div data-testid="add-queue-form">Formularz kolejki</div>,
+}))
+
+vi.mock('@/components/queue/edit-queue-form', () => ({
+  EditQueueForm: () => <div data-testid="edit-queue-form">Edycja kolejki</div>,
+}))
+
+vi.mock('@/components/queue/promote-modal', () => ({
+  PromoteModal: () => null,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import QueuePage from '@/app/dashboard/queue/page'
+
+// ── Test Data ────────────────────────────────────────────────────────────────
+
+const mockStats = {
+  totalQueued: 8,
+  oldestQueueDate: '2026-03-01',
+  manualOrderCount: 2,
+  queuesByDate: [
+    { date: '2026-04-15', count: 5 },
+    { date: '2026-04-20', count: 3 },
+  ],
+}
+
+const mockQueues = [
+  { id: 'q-1', position: 1, queueDate: '2026-04-15', client: { firstName: 'Jan', lastName: 'Kowalski' } },
+  { id: 'q-2', position: 2, queueDate: '2026-04-15', client: { firstName: 'Anna', lastName: 'Nowak' } },
+]
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('QueuePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading state while data is fetching', () => {
+    mockQueueGetAll.mockReturnValue(new Promise(() => {}))
+    mockQueueGetStats.mockReturnValue(new Promise(() => {}))
+    mockClientsGetAll.mockReturnValue(new Promise(() => {}))
+
+    render(<QueuePage />)
+    expect(screen.getByTestId('loading-state')).toBeInTheDocument()
+  })
+
+  it('renders page hero with title after loading', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Kolejka rezerwacji')).toBeInTheDocument()
+    })
+  })
+
+  it('renders stat cards after loading', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-W kolejce')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Najstarsza data')).toBeInTheDocument()
+    })
+  })
+
+  it('renders "Add to queue" button', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Dodaj do kolejki')).toBeInTheDocument()
+    })
+  })
+
+  it('renders "Rebuild" button', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByText('Przebuduj numerację')).toBeInTheDocument()
+    })
+  })
+
+  it('renders queue list with items', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-list')).toBeInTheDocument()
+    })
+  })
+
+  it('renders "All" date button with count', async () => {
+    mockQueueGetAll.mockResolvedValue(mockQueues)
+    mockQueueGetStats.mockResolvedValue(mockStats)
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByText(/Wszystkie \(2\)/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no queue items', async () => {
+    mockQueueGetAll.mockResolvedValue([])
+    mockQueueGetStats.mockResolvedValue({ ...mockStats, totalQueued: 0, queuesByDate: [] })
+    mockClientsGetAll.mockResolvedValue([])
+
+    render(<QueuePage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument()
+      expect(screen.getByText('Kolejka jest pusta')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/frontend/__tests__/pages/ReservationsListPage.test.tsx
+++ b/apps/frontend/__tests__/pages/ReservationsListPage.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Reservations List Page Tests
+ *
+ * Tests the reservations list page (/dashboard/reservations/list):
+ * - Renders page hero with title
+ * - Displays stat cards
+ * - Shows "New Reservation" button
+ * - Calendar/List view toggle
+ * - Renders reservation list component
+ * - Loading state handling
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetReservations } = vi.hoisted(() => ({
+  mockGetReservations: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/reservations/list',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/api/reservations', () => ({
+  getReservations: mockGetReservations,
+}))
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    reservations: {
+      iconBg: 'bg-blue-500',
+      text: 'text-blue-600',
+      textDark: 'text-blue-400',
+      gradient: 'from-blue-500 to-cyan-500',
+      gradientSubtle: 'from-blue-50 to-cyan-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle, action }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+      {action}
+    </div>
+  ),
+  StatCard: ({ label, value }: any) => (
+    <div data-testid={`stat-${label}`}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  CardContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}))
+
+vi.mock('@/components/reservations/reservations-list', () => ({
+  ReservationsList: () => <div data-testid="reservations-list">Lista rezerwacji</div>,
+}))
+
+vi.mock('@/components/reservations/create-reservation-form', () => ({
+  CreateReservationForm: () => <div data-testid="create-form">Formularz nowej rezerwacji</div>,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import ReservationsListPage from '@/app/dashboard/reservations/list/page'
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ReservationsListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetReservations.mockResolvedValue([
+      {
+        id: 'res-1',
+        status: 'CONFIRMED',
+        startDateTime: '2026-03-15T14:00:00Z',
+        guests: 120,
+        client: { firstName: 'Jan', lastName: 'Kowalski' },
+      },
+      {
+        id: 'res-2',
+        status: 'PENDING',
+        startDateTime: '2026-03-16T12:00:00Z',
+        guests: 50,
+        client: { firstName: 'Anna', lastName: 'Nowak' },
+      },
+    ])
+  })
+
+  it('renders page hero with title', async () => {
+    render(<ReservationsListPage />)
+    expect(screen.getByText('Rezerwacje')).toBeInTheDocument()
+  })
+
+  it('renders subtitle', () => {
+    render(<ReservationsListPage />)
+    expect(screen.getByText('Zarządzaj rezerwacjami sal weselnych')).toBeInTheDocument()
+  })
+
+  it('renders "New Reservation" button', () => {
+    render(<ReservationsListPage />)
+    expect(screen.getByText('Nowa Rezerwacja')).toBeInTheDocument()
+  })
+
+  it('renders stat cards', async () => {
+    render(<ReservationsListPage />)
+    await waitFor(() => {
+      expect(screen.getByTestId('stat-Wszystkie')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Potwierdzone')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Oczekujące')).toBeInTheDocument()
+      expect(screen.getByTestId('stat-Ten miesiąc')).toBeInTheDocument()
+    })
+  })
+
+  it('renders list/calendar view toggle', () => {
+    render(<ReservationsListPage />)
+    expect(screen.getByText('Lista')).toBeInTheDocument()
+    expect(screen.getByText('Kalendarz')).toBeInTheDocument()
+  })
+
+  it('calendar link points to calendar view', () => {
+    render(<ReservationsListPage />)
+    const calendarLink = screen.getByText('Kalendarz').closest('a')
+    expect(calendarLink).toHaveAttribute('href', '/dashboard/reservations/calendar')
+  })
+
+  it('renders reservations list component', () => {
+    render(<ReservationsListPage />)
+    expect(screen.getByTestId('reservations-list')).toBeInTheDocument()
+  })
+
+  it('calls getReservations on mount', async () => {
+    render(<ReservationsListPage />)
+    await waitFor(() => {
+      expect(mockGetReservations).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/frontend/__tests__/pages/SettingsPage.test.tsx
+++ b/apps/frontend/__tests__/pages/SettingsPage.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Settings Page Tests
+ *
+ * Tests the settings page (/dashboard/settings):
+ * - Renders page hero with title and subtitle
+ * - Displays four tab triggers (Users, Roles, Company, Archive)
+ * - Default tab is "users"
+ * - Each tab content component renders
+ */
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), back: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/dashboard/settings',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...classes: any[]) => classes.filter(Boolean).join(' '),
+}))
+
+vi.mock('@/lib/design-tokens', () => ({
+  moduleAccents: {
+    settings: {
+      iconBg: 'bg-gray-500',
+      text: 'text-gray-600',
+      textDark: 'text-gray-400',
+      gradient: 'from-gray-500 to-slate-500',
+      gradientSubtle: 'from-gray-50 to-slate-50',
+    },
+  },
+}))
+
+vi.mock('lucide-react', () => new Proxy({}, {
+  get: (_, name) => (props: any) => <span data-testid={`icon-${String(name).toLowerCase()}`} {...props} />,
+}))
+
+vi.mock('@/components/shared', () => ({
+  PageLayout: ({ children }: any) => <div data-testid="page-layout">{children}</div>,
+  PageHero: ({ title, subtitle }: any) => (
+    <div data-testid="page-hero">
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+}))
+
+vi.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children, value, onValueChange }: any) => (
+    <div data-testid="tabs" data-value={value}>{children}</div>
+  ),
+  TabsList: ({ children }: any) => <div data-testid="tabs-list" role="tablist">{children}</div>,
+  TabsTrigger: ({ children, value, ...props }: any) => (
+    <button role="tab" data-value={value} {...props}>{children}</button>
+  ),
+  TabsContent: ({ children, value }: any) => (
+    <div data-testid={`tab-content-${value}`} role="tabpanel">{children}</div>
+  ),
+}))
+
+vi.mock('@/components/settings/UsersTab', () => ({
+  UsersTab: () => <div data-testid="users-tab">Zarządzanie użytkownikami</div>,
+}))
+
+vi.mock('@/components/settings/RolesTab', () => ({
+  RolesTab: () => <div data-testid="roles-tab">Zarządzanie rolami</div>,
+}))
+
+vi.mock('@/components/settings/CompanyTab', () => ({
+  CompanyTab: () => <div data-testid="company-tab">Dane firmy</div>,
+}))
+
+vi.mock('@/components/settings/ArchiveTab', () => ({
+  ArchiveTab: () => <div data-testid="archive-tab">Archiwizacja danych</div>,
+}))
+
+// ── Import ───────────────────────────────────────────────────────────────────
+
+import SettingsPage from '@/app/dashboard/settings/page'
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders page hero with title', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('Ustawienia')).toBeInTheDocument()
+  })
+
+  it('renders subtitle', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText(/Zarządzanie użytkownikami, rolami/)).toBeInTheDocument()
+  })
+
+  it('renders four tab triggers', () => {
+    render(<SettingsPage />)
+    const tabs = screen.getAllByRole('tab')
+    expect(tabs).toHaveLength(4)
+  })
+
+  it('renders Users tab trigger with icon', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('Użytkownicy')).toBeInTheDocument()
+  })
+
+  it('renders Roles tab trigger', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('Role i uprawnienia')).toBeInTheDocument()
+  })
+
+  it('renders Company tab trigger', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('Dane firmy')).toBeInTheDocument()
+  })
+
+  it('renders Archive tab trigger', () => {
+    render(<SettingsPage />)
+    expect(screen.getByText('Archiwizacja')).toBeInTheDocument()
+  })
+
+  it('default tab value is "users"', () => {
+    render(<SettingsPage />)
+    const tabs = screen.getByTestId('tabs')
+    expect(tabs).toHaveAttribute('data-value', 'users')
+  })
+
+  it('renders UsersTab content', () => {
+    render(<SettingsPage />)
+    expect(screen.getByTestId('users-tab')).toBeInTheDocument()
+  })
+
+  it('renders RolesTab content', () => {
+    render(<SettingsPage />)
+    expect(screen.getByTestId('roles-tab')).toBeInTheDocument()
+  })
+
+  it('renders CompanyTab content', () => {
+    render(<SettingsPage />)
+    expect(screen.getByTestId('company-tab')).toBeInTheDocument()
+  })
+
+  it('renders ArchiveTab content', () => {
+    render(<SettingsPage />)
+    expect(screen.getByTestId('archive-tab')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Dodano testy jednostkowe dla 8 najważniejszych stron Next.js w `apps/frontend/__tests__/pages/`
- Każda strona testowana pod kątem: renderowania, kluczowych elementów UI, stanów ładowania/błędów, interakcji z API

## Pokryte strony
| Strona | Plik testowy | Testy |
|--------|-------------|-------|
| `/login` | `LoginPage.test.tsx` | formularz, walidacja, API login, redirect, błędy |
| `/forgot-password` | `ForgotPasswordPage.test.tsx` | walidacja email, API call, stan sukcesu |
| `/dashboard` | `DashboardPage.test.tsx` | stat cards, upcoming events, loading/error |
| `/dashboard/reservations/list` | `ReservationsListPage.test.tsx` | statystyki, toggle lista/kalendarz |
| `/dashboard/clients` | `ClientsPage.test.tsx` | wyszukiwanie, filtry, lista klientów |
| `/dashboard/queue` | `QueuePage.test.tsx` | kolejka, stat cards, empty state |
| `/dashboard/settings` | `SettingsPage.test.tsx` | 4 taby (Users, Roles, Company, Archive) |
| `/dashboard/audit-log` | `AuditLogPage.test.tsx` | dziennik audytu, filtry, statystyki |
| `/dashboard/deposits` | `DepositsPage.test.tsx` | zaliczki, filtry statusów, wyszukiwanie |

## Podejście
- Mockowanie hooków API (`vi.hoisted()` + `vi.mock()`)
- Mockowanie `next/navigation`, `framer-motion`, `lucide-react`
- Mockowanie komponentów shared (PageLayout, PageHero, StatCard) dla izolacji
- Wzorce zgodne z istniejącymi testami w `__tests__/components/`

## Test plan
- [ ] CI przechodzi (vitest)
- [ ] Brak regresji w istniejących testach

🤖 Generated with [Claude Code](https://claude.com/claude-code)