### PR TITLE
chore(ci): podnieś coverage threshold 70% → 80%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
     # Project-level coverage (overall repository)
     project:
       default:
-        target: 70%
+        target: 80%
         threshold: 2%  # Allow 2% drop without failing
         flags:
           - backend-unit
@@ -16,7 +16,7 @@ coverage:
     # Patch coverage (only new/changed code in PR)
     patch:
       default:
-        target: 80%
+        target: 85%
         threshold: 5%
 
 # Flag management


### PR DESCRIPTION
## Summary
- Project target: 70% → **80%**
- Patch target: 80% → **85%**

## Uzasadnienie
Backend unit coverage wynosi **85.23%** — próg 70% był 15pp poniżej realnej wartości.
Podniesienie do 80% zapobiega cichej regresji.

## Dane z audytu (2026-03-26)
| Metryka | Wartość | Stary próg | Nowy próg |
|---------|---------|-----------|-----------|
| Statements | 85.23% | 70% | **80%** ✅ |
| Branches | 87.73% | 70% | **80%** ✅ |
| Functions | 88.11% | 70% | **80%** ✅ |

## Test plan
- [ ] Codecov nie blokuje PR-ów (threshold 2% marginu)
- [ ] Backend CI przechodzi

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)