### PR TITLE
fix(ci): Codecov tokenless upload — usunięcie wymagania tokenu

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -97,14 +97,13 @@ jobs:
 
       - name: Upload Unit Test Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         timeout-minutes: 2
         continue-on-error: true
         with:
           files: ./apps/backend/coverage/lcov.info
           flags: backend-unit
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ========================================
   # Job 3: Integration Tests (with PostgreSQL)
@@ -160,14 +159,13 @@ jobs:
 
       - name: Upload Integration Test Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         timeout-minutes: 2
         continue-on-error: true
         with:
           files: ./apps/backend/coverage/lcov.info
           flags: backend-integration
           fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   # ========================================
   # Job 4: Security Tests (with PostgreSQL)


### PR DESCRIPTION
## Summary
- Upgrade `codecov/codecov-action` v4 → **v5**
- Usunięcie `token: ${{ secrets.CODECOV_TOKEN }}` — org ma ustawione "Not required"
- Upload powinien działać bez tokenu dla publicznych/autoryzowanych repozytoriów

## Zmienione
- Upload Unit Test Coverage: v4→v5, usunięto token
- Upload Integration Test Coverage: v4→v5, usunięto token

## Test plan
- [ ] Codecov upload przechodzi w backend-ci workflow
- [ ] Coverage widoczne na Codecov dashboard

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)