### PR TITLE
feat(ui/ux): dokończenie EPIC #233 + #232 catering unifikacja

### DIFF
--- a/apps/frontend/app/dashboard/catering/orders/[id]/components/OrderHeader.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/[id]/components/OrderHeader.tsx
@@ -11,6 +11,7 @@ import {
   Download,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { moduleAccents } from '@/lib/design-tokens';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -46,7 +47,7 @@ export function OrderHeader({
   onDownloadPDF,
 }: OrderHeaderProps) {
   return (
-    <div className="relative overflow-hidden bg-gradient-to-br from-orange-500 via-amber-500 to-orange-600 px-6 py-8 text-white">
+    <div className={`relative overflow-hidden bg-gradient-to-br ${moduleAccents.catering.gradient} px-6 py-8 text-white`}>
       <div className="pointer-events-none absolute -right-16 -top-16 h-56 w-56 rounded-full bg-white/10" />
       <div className="pointer-events-none absolute -bottom-10 -left-10 h-40 w-40 rounded-full bg-white/5" />
       <div className="pointer-events-none absolute right-32 bottom-0 h-24 w-24 rounded-full bg-white/5" />

--- a/apps/frontend/app/dashboard/catering/orders/[id]/edit/page.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/[id]/edit/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { ArrowLeft, Loader2, Save } from 'lucide-react';
+import { LoadingState } from '@/components/shared/LoadingState';
+import { moduleAccents } from '@/lib/design-tokens';
 import { toast } from 'sonner';
 import { useCateringOrder, useUpdateCateringOrder } from '@/hooks/use-catering-orders';
 import { useCateringTemplates } from '@/hooks/use-catering';
@@ -179,18 +181,14 @@ export default function EditOrderPage() {
     : '';
 
   if (isLoading || !form) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
-    );
+    return <LoadingState message="Ładowanie zamówienia..." className="py-24" />;
   }
 
   return (
     <div className="space-y-6 p-6">
 
       {/* ═══ GRADIENT HERO HEADER ═══ */}
-      <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-orange-500 via-amber-500 to-orange-600 px-6 py-6 text-white shadow-lg">
+      <div className={`relative overflow-hidden rounded-2xl bg-gradient-to-r ${moduleAccents.catering.gradient} px-6 py-6 text-white shadow-lg`}>
         {/* Decorative circles */}
         <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-white/10" />
         <div className="pointer-events-none absolute -left-6 -bottom-8 h-28 w-28 rounded-full bg-white/5" />

--- a/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Loader2, AlertCircle, ArrowLeft } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
 import {
   useCateringOrder,
@@ -10,7 +10,7 @@ import {
   useUpdateCateringOrder,
   useDeleteCateringDeposit,
 } from '@/hooks/use-catering-orders';
-import { Button } from '@/components/ui/button';
+import { LoadingState, EmptyState } from '@/components/shared';
 import { ChangeStatusDialog } from '../components/ChangeStatusDialog';
 import { DiscountDialog } from '../components/DiscountDialog';
 import { AddDepositDialog } from '../components/AddDepositDialog';
@@ -89,23 +89,19 @@ export default function CateringOrderDetailPage() {
   };
 
   if (isLoading) {
-    return (
-      <div className="flex flex-col items-center justify-center py-32 gap-4">
-        <Loader2 className="h-10 w-10 animate-spin text-primary-500" />
-        <p className="text-sm text-neutral-500 dark:text-neutral-400">Wczytywanie zamówienia…</p>
-      </div>
-    );
+    return <LoadingState message="Wczytywanie zamówienia…" className="py-32" />;
   }
 
   if (!order) {
     return (
-      <div className="flex flex-col items-center justify-center py-32 gap-4">
-        <AlertCircle className="h-12 w-12 text-neutral-300" />
-        <p className="font-semibold text-neutral-600 dark:text-neutral-400">Zamówienie nie istnieje</p>
-        <Button variant="outline" onClick={() => router.push('/dashboard/catering/orders')}>
-          <ArrowLeft className="mr-2 h-4 w-4" /> Powrót do listy
-        </Button>
-      </div>
+      <EmptyState
+        icon={AlertCircle}
+        title="Nie znaleziono zamówienia"
+        description="Zamówienie nie istnieje lub zostało usunięte."
+        actionLabel="Powrót do listy"
+        actionHref="/dashboard/catering/orders"
+        className="py-32"
+      />
     );
   }
 

--- a/apps/frontend/app/dashboard/catering/orders/components/OrderTimeline.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/components/OrderTimeline.tsx
@@ -204,8 +204,7 @@ export function OrderTimeline({ orderId }: { orderId: string }) {
                     <div className="flex items-center gap-1.5">
                       <span className="text-neutral-300 dark:text-neutral-600 text-xs">·</span>
                       <div
-                        className="w-5 h-5 rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 flex items-center justify-center text-white shrink-0"
-                        style={{ fontSize: '9px', fontWeight: 700, lineHeight: 1 }}
+                        className="w-5 h-5 rounded-full bg-gradient-to-br from-indigo-500 to-violet-500 flex items-center justify-center text-white shrink-0 text-[9px] font-bold leading-none"
                       >
                         {getAuthorInitials(entry.changedBy)}
                       </div>

--- a/apps/frontend/app/dashboard/catering/orders/page.tsx
+++ b/apps/frontend/app/dashboard/catering/orders/page.tsx
@@ -8,7 +8,6 @@ import {
   CheckCircle2,
   Clock,
   TrendingUp,
-  Loader2,
 } from 'lucide-react';
 import { useCateringOrders } from '@/hooks/use-catering-orders';
 import { Button } from '@/components/ui/button';
@@ -16,22 +15,11 @@ import { Card, CardContent } from '@/components/ui/card';
 import { OrdersTable } from './components/OrdersTable';
 import { OrdersFilters } from './components/OrdersFilters';
 import { NewOrderWizard } from './components/NewOrderWizard';
-import { PageLayout, PageHero, StatCard } from '@/components/shared';
-import type { ModuleAccent } from '@/lib/design-tokens';
+import { PageLayout, PageHero, StatCard, LoadingState, EmptyState } from '@/components/shared';
+import { moduleAccents } from '@/lib/design-tokens';
 import type { CateringOrdersFilter } from '@/types/catering-order.types';
 
-// Accent zdefiniowany inline — nie przez moduleAccents[key], żeby uniknąć błędu przy cache buildowym
-const CATERING_ACCENT: ModuleAccent = {
-  name: 'Catering',
-  gradient: 'from-orange-600 via-orange-500 to-amber-600',
-  gradientSubtle: 'from-orange-500/5 via-amber-500/5 to-orange-500/5',
-  iconBg: 'from-orange-500 to-amber-500',
-  text: 'text-orange-600',
-  textDark: 'dark:text-orange-400',
-  ring: 'ring-orange-500/20',
-  badge: 'bg-orange-100 dark:bg-orange-900/30',
-  badgeText: 'text-orange-700 dark:text-orange-300',
-};
+const CATERING_ACCENT = moduleAccents.catering;
 
 export default function CateringOrdersPage() {
   const router = useRouter();
@@ -170,12 +158,18 @@ export default function CateringOrdersPage() {
         <CardContent className="p-4 sm:p-6 space-y-4">
           <OrdersFilters filter={filter} onChange={handleFilterChange} />
           {isLoading ? (
-            <div className="flex items-center justify-center py-16">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            </div>
+            <LoadingState variant="skeleton" rows={6} message="Wczytywanie zamówień..." />
+          ) : !data?.data?.length ? (
+            <EmptyState
+              icon={ShoppingBag}
+              title="Brak zamówień"
+              description="Utwórz pierwsze zamówienie cateringowe"
+              actionLabel="Nowe zamówienie"
+              onAction={() => setShowWizard(true)}
+            />
           ) : (
             <OrdersTable
-              orders={data?.data ?? []}
+              orders={data.data}
               meta={data?.meta}
               onPageChange={handlePageChange}
               onRowClick={(id) => router.push(`/dashboard/catering/orders/${id}`)}

--- a/apps/frontend/app/dashboard/catering/templates/page.tsx
+++ b/apps/frontend/app/dashboard/catering/templates/page.tsx
@@ -22,19 +22,9 @@ import {
 import { CateringTemplateList } from './components/CateringTemplateList';
 import { CateringTemplateForm } from './components/CateringTemplateForm';
 import type { CateringTemplate } from '@/types/catering.types';
-import type { ModuleAccent } from '@/lib/design-tokens';
+import { moduleAccents } from '@/lib/design-tokens';
 
-const CATERING_ACCENT: ModuleAccent = {
-  name: 'Catering',
-  gradient: 'from-orange-600 via-orange-500 to-amber-600',
-  gradientSubtle: 'from-orange-500/5 via-amber-500/5 to-orange-500/5',
-  iconBg: 'from-orange-500 to-amber-500',
-  text: 'text-orange-600',
-  textDark: 'dark:text-orange-400',
-  ring: 'ring-orange-500/20',
-  badge: 'bg-orange-100 dark:bg-orange-900/30',
-  badgeText: 'text-orange-700 dark:text-orange-300',
-};
+const CATERING_ACCENT = moduleAccents.catering;
 
 export default function CateringTemplatesPage() {
   const [formOpen, setFormOpen] = useState(false);

--- a/apps/frontend/app/dashboard/components/SessionTimeoutModal.tsx
+++ b/apps/frontend/app/dashboard/components/SessionTimeoutModal.tsx
@@ -77,7 +77,7 @@ export default function SessionTimeoutModal() {
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2
                      rounded-2xl border border-orange-200 bg-white p-8 shadow-2xl
                      animate-in fade-in-0 zoom-in-95 slide-in-from-left-1/2 slide-in-from-top-[48%]
-                     dark:border-orange-800 dark:bg-gray-900"
+                     dark:border-orange-800 dark:bg-neutral-900"
         >
           {/* Timer ring */}
           <div className="mx-auto mb-6 flex h-28 w-28 items-center justify-center relative">
@@ -88,7 +88,7 @@ export default function SessionTimeoutModal() {
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="6"
-                className="text-gray-200 dark:text-gray-700"
+                className="text-neutral-200 dark:text-neutral-700"
               />
               {/* Progress circle */}
               <circle
@@ -108,21 +108,21 @@ export default function SessionTimeoutModal() {
                 }`}
               />
             </svg>
-            <span className="absolute text-3xl font-bold tabular-nums text-gray-900 dark:text-white">
+            <span className="absolute text-3xl font-bold tabular-nums text-neutral-900 dark:text-white">
               {remainingSeconds ?? 0}
             </span>
           </div>
 
           {/* Title */}
-          <AlertDialog.Title className="mb-2 text-center text-xl font-semibold text-gray-900 dark:text-white">
+          <AlertDialog.Title className="mb-2 text-center text-xl font-semibold text-neutral-900 dark:text-white">
             <Clock className="mb-1 inline-block h-5 w-5 text-orange-500" />{' '}
             Sesja wygasa
           </AlertDialog.Title>
 
           {/* Description */}
-          <AlertDialog.Description className="mb-8 text-center text-sm text-gray-600 dark:text-gray-400">
+          <AlertDialog.Description className="mb-8 text-center text-sm text-neutral-600 dark:text-neutral-400">
             Z powodu braku aktywności Twoja sesja wygaśnie za{' '}
-            <strong className="text-gray-900 dark:text-white">
+            <strong className="text-neutral-900 dark:text-white">
               {remainingSeconds ?? 0} sekund
             </strong>.
             Kliknij &bdquo;Przedłuż sesję&rdquo;, aby kontynuować pracę.
@@ -136,7 +136,7 @@ export default function SessionTimeoutModal() {
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-orange-500 px-6 py-2.5
                            text-sm font-medium text-white shadow-sm transition-colors
                            hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2
-                           dark:focus:ring-offset-gray-900"
+                           dark:focus:ring-offset-neutral-900"
               >
                 <RefreshCw className="h-4 w-4" />
                 Przedłuż sesję
@@ -146,11 +146,11 @@ export default function SessionTimeoutModal() {
             <AlertDialog.Cancel asChild>
               <button
                 onClick={handleLogout}
-                className="inline-flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-6 py-2.5
-                           text-sm font-medium text-gray-700 shadow-sm transition-colors
-                           hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2
-                           dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700
-                           dark:focus:ring-offset-gray-900"
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-neutral-300 bg-white px-6 py-2.5
+                           text-sm font-medium text-neutral-700 shadow-sm transition-colors
+                           hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-neutral-400 focus:ring-offset-2
+                           dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700
+                           dark:focus:ring-offset-neutral-900"
               >
                 <LogOut className="h-4 w-4" />
                 Wyloguj

--- a/apps/frontend/app/dashboard/reports/components/ReportFilters.tsx
+++ b/apps/frontend/app/dashboard/reports/components/ReportFilters.tsx
@@ -43,19 +43,19 @@ export function ReportFilters({
             <div>
               <label className="block text-xs text-neutral-500 dark:text-neutral-400 mb-1">Od</label>
               <input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)}
-                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500" />
             </div>
             <div>
               <label className="block text-xs text-neutral-500 dark:text-neutral-400 mb-1">Do</label>
               <input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)}
-                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500" />
+                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500" />
             </div>
           </div>
           {activeTab === 'revenue' && (
             <div>
               <label className="block text-xs text-neutral-500 dark:text-neutral-400 mb-1">Grupuj po</label>
               <select value={groupBy} onChange={(e) => setGroupBy(e.target.value as GroupByPeriod)}
-                className="w-full sm:w-auto px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
+                className="w-full sm:w-auto px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500">
                 <option value="day">{"Dzień"}</option>
                 <option value="week">{"Tydzień"}</option>
                 <option value="month">{"Miesiąc"}</option>

--- a/apps/frontend/app/dashboard/reservations/calendar/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/calendar/page.tsx
@@ -286,7 +286,7 @@ export default function CalendarPage() {
           <div className="flex items-center gap-2">
             <Filter className="h-4 w-4 text-neutral-400 flex-shrink-0" />
             <select value={hallFilter} onChange={(e) => setHallFilter(e.target.value)}
-              className="rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-700 dark:text-neutral-300 focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-full sm:w-auto"
+              className="rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 px-3 py-1.5 text-sm text-neutral-700 dark:text-neutral-300 focus:ring-2 focus:ring-ring focus:border-transparent w-full sm:w-auto"
             >
               <option value="all">Wszystkie sale</option>
               {halls.filter((h) => h.isActive).map((h) => (<option key={h.id} value={h.id}>{h.name}</option>))}

--- a/apps/frontend/app/forgot-password/page.tsx
+++ b/apps/frontend/app/forgot-password/page.tsx
@@ -167,7 +167,7 @@ export default function ForgotPasswordPage() {
                         type="email"
                         autoComplete="email"
                         autoFocus
-                        className="w-full pl-12 pr-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-violet-500/20 rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200"
+                        className="w-full pl-12 pr-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-ring/20 rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200"
                         placeholder="twoj@email.pl"
                         value={email}
                         onChange={(e) => {

--- a/apps/frontend/app/login/page.tsx
+++ b/apps/frontend/app/login/page.tsx
@@ -176,7 +176,7 @@ export default function LoginPage() {
                   className={`w-full pl-12 pr-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 ${
                     fieldErrors.email
                       ? 'border-error-500 focus:border-error-600 focus:ring-error-500/20'
-                      : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-violet-500/20'
+                      : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-ring/20'
                   } rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200`}
                   placeholder="twoj@email.pl"
                   value={formData.email}
@@ -223,7 +223,7 @@ export default function LoginPage() {
                   className={`w-full pl-12 pr-4 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 ${
                     fieldErrors.password
                       ? 'border-error-500 focus:border-error-600 focus:ring-error-500/20'
-                      : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-violet-500/20'
+                      : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-ring/20'
                   } rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200`}
                   placeholder="••••••••"
                   value={formData.password}

--- a/apps/frontend/app/not-found.tsx
+++ b/apps/frontend/app/not-found.tsx
@@ -2,13 +2,13 @@ import Link from 'next/link'
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-50">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-950">
       <div className="text-center">
-        <h1 className="text-6xl font-bold text-neutral-900">404</h1>
-        <p className="mt-4 text-xl text-neutral-600">Strona nie została znaleziona</p>
+        <h1 className="text-6xl font-bold text-neutral-900 dark:text-neutral-100">404</h1>
+        <p className="mt-4 text-xl text-neutral-600 dark:text-neutral-400">Strona nie została znaleziona</p>
         <Link
           href="/dashboard"
-          className="mt-8 inline-block rounded-lg bg-blue-600 px-6 py-3 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          className="mt-8 inline-block rounded-lg bg-violet-600 dark:bg-violet-500 px-6 py-3 text-sm font-medium text-white hover:bg-violet-700 dark:hover:bg-violet-400 transition-colors"
         >
           Wróć do panelu
         </Link>

--- a/apps/frontend/app/reset-password/page.tsx
+++ b/apps/frontend/app/reset-password/page.tsx
@@ -213,7 +213,7 @@ function ResetPasswordContent() {
                         type={showPassword ? 'text' : 'password'}
                         autoComplete="new-password"
                         autoFocus
-                        className="w-full pl-12 pr-12 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-violet-500/20 rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200"
+                        className="w-full pl-12 pr-12 py-3 bg-neutral-50 dark:bg-neutral-900/50 border-2 border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-ring/20 rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200"
                         placeholder="••••••••••••"
                         value={formData.newPassword}
                         onChange={(e) => {
@@ -282,7 +282,7 @@ function ResetPasswordContent() {
                             ? passwordsMatch
                               ? 'border-emerald-400 focus:border-emerald-500 focus:ring-emerald-500/20'
                               : 'border-error-400 focus:border-error-500 focus:ring-error-500/20'
-                            : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-violet-500/20'
+                            : 'border-neutral-200 dark:border-neutral-700 focus:border-violet-500 focus:ring-ring/20'
                         } rounded-xl text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 dark:placeholder-neutral-400 focus:outline-none focus:ring-4 transition-all duration-200`}
                         placeholder="••••••••••••"
                         value={formData.confirmPassword}

--- a/apps/frontend/components/clients/delete-client-modal.tsx
+++ b/apps/frontend/components/clients/delete-client-modal.tsx
@@ -130,11 +130,11 @@ export function DeleteClientModal({
                     </div>
                   )}
                   {summary.archived > 0 && (
-                    <div className="flex items-center gap-2 p-2.5 bg-gray-50 dark:bg-gray-900/20 rounded-lg">
-                      <Archive className="h-4 w-4 text-gray-500" />
+                    <div className="flex items-center gap-2 p-2.5 bg-neutral-50 dark:bg-neutral-900/20 rounded-lg">
+                      <Archive className="h-4 w-4 text-neutral-500" />
                       <div>
                         <p className="text-xs text-muted-foreground">Zarchiwizowane</p>
-                        <p className="text-sm font-bold text-gray-600 dark:text-gray-400">{summary.archived}</p>
+                        <p className="text-sm font-bold text-neutral-600 dark:text-neutral-400">{summary.archived}</p>
                       </div>
                     </div>
                   )}

--- a/apps/frontend/components/menu/CategorySettingsSection.tsx
+++ b/apps/frontend/components/menu/CategorySettingsSection.tsx
@@ -164,7 +164,7 @@ export default function CategorySettingsSection({
                         type="checkbox"
                         checked={enabled}
                         onChange={(e) => handleToggle(category.id, e.target.checked)}
-                        className="w-6 h-6 rounded-lg border-2 border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 cursor-pointer transition-all"
+                        className="w-6 h-6 rounded-lg border-2 border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-pointer transition-all"
                       />
                     </div>
                     <div className="flex items-center gap-2">
@@ -221,7 +221,7 @@ export default function CategorySettingsSection({
                           }
                           min="0"
                           step="0.5"
-                          className={`w-full px-4 py-2.5 border-2 rounded-xl text-neutral-900 dark:text-neutral-100 bg-white dark:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all ${
+                          className={`w-full px-4 py-2.5 border-2 rounded-xl text-neutral-900 dark:text-neutral-100 bg-white dark:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all ${
                             hasError ? 'border-red-400' : 'border-neutral-300 dark:border-neutral-600'
                           }`}
                         />
@@ -242,7 +242,7 @@ export default function CategorySettingsSection({
                           }
                           min="0"
                           step="0.5"
-                          className={`w-full px-4 py-2.5 border-2 rounded-xl text-neutral-900 dark:text-neutral-100 bg-white dark:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all ${
+                          className={`w-full px-4 py-2.5 border-2 rounded-xl text-neutral-900 dark:text-neutral-100 bg-white dark:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all ${
                             hasError ? 'border-red-400' : 'border-neutral-300 dark:border-neutral-600'
                           }`}
                         />
@@ -283,7 +283,7 @@ export default function CategorySettingsSection({
                           onChange={(e) =>
                             handleChange(category.id, 'isRequired', e.target.checked)
                           }
-                          className="w-5 h-5 rounded border-2 border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-blue-500 cursor-pointer"
+                          className="w-5 h-5 rounded border-2 border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-ring cursor-pointer"
                         />
                         <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-300">Wymagana</span>
                       </div>
@@ -301,7 +301,7 @@ export default function CategorySettingsSection({
                           handleChange(category.id, 'customLabel', e.target.value || undefined)
                         }
                         placeholder={category.name}
-                        className="w-full px-4 py-2.5 border-2 border-neutral-200 dark:border-neutral-700 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                        className="w-full px-4 py-2.5 border-2 border-neutral-200 dark:border-neutral-700 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
                       />
                     </div>
 

--- a/apps/frontend/components/menu/PackageForm.tsx
+++ b/apps/frontend/components/menu/PackageForm.tsx
@@ -247,7 +247,7 @@ export default function PackageForm({
               required
               minLength={3}
               placeholder="np. Pakiet Komunijny Elegancki"
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
             />
           </div>
 
@@ -264,7 +264,7 @@ export default function PackageForm({
               onChange={handleChange}
               maxLength={100}
               placeholder="Krótki opis wyświetlany na karcie pakietu"
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
             />
             <p className="text-xs text-neutral-500 dark:text-neutral-400 mt-1">{formData.shortDescription.length}/100 znaków</p>
           </div>
@@ -281,7 +281,7 @@ export default function PackageForm({
               onChange={handleChange}
               rows={4}
               placeholder="Szczegółowy opis pakietu, co zawiera, dla kogo jest przeznaczony..."
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all resize-none"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 placeholder:text-neutral-400 dark:placeholder:text-neutral-500 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all resize-none"
             />
           </div>
         </div>
@@ -311,7 +311,7 @@ export default function PackageForm({
                 required
                 placeholder="180.00"
                 pattern="[0-9]+\.?[0-9]*"
-                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
               />
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400 font-medium">zł</span>
             </div>
@@ -331,7 +331,7 @@ export default function PackageForm({
                 required
                 placeholder="90.00"
                 pattern="[0-9]+\.?[0-9]*"
-                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
               />
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400 font-medium">zł</span>
             </div>
@@ -350,7 +350,7 @@ export default function PackageForm({
                 onChange={handleChange}
                 placeholder="0.00"
                 pattern="[0-9]+\.?[0-9]*"
-                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+                className="w-full px-4 py-3 pr-12 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
               />
               <span className="absolute right-4 top-1/2 -translate-y-1/2 text-neutral-500 dark:text-neutral-400 font-medium">zł</span>
             </div>

--- a/apps/frontend/components/menu/dish-selector/DishCard.tsx
+++ b/apps/frontend/components/menu/dish-selector/DishCard.tsx
@@ -100,7 +100,7 @@ export function DishCard({
               <select
                 value={quantity}
                 onChange={(e) => onQuantityChange(parseFloat(e.target.value))}
-                className="w-full px-3 py-1.5 border border-blue-300 dark:border-blue-700 rounded-md text-sm font-bold bg-white dark:bg-neutral-900 text-blue-900 dark:text-blue-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all cursor-pointer"
+                className="w-full px-3 py-1.5 border border-blue-300 dark:border-blue-700 rounded-md text-sm font-bold bg-white dark:bg-neutral-900 text-blue-900 dark:text-blue-100 focus:ring-2 focus:ring-ring focus:border-blue-500 transition-all cursor-pointer"
               >
                 {availableOptions.map(opt => (
                   <option key={opt} value={opt}>

--- a/apps/frontend/components/menu/package-form/PackageDisplaySection.tsx
+++ b/apps/frontend/components/menu/package-form/PackageDisplaySection.tsx
@@ -40,7 +40,7 @@ export default function PackageDisplaySection({
                 name="isPopular"
                 checked={formData.isPopular}
                 onChange={handleChange}
-                className="w-5 h-5 rounded border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-blue-500 cursor-pointer"
+                className="w-5 h-5 rounded border-neutral-300 dark:border-neutral-600 text-blue-600 focus:ring-2 focus:ring-ring cursor-pointer"
               />
             </div>
             <span className="text-sm font-semibold text-neutral-700 dark:text-neutral-300 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
@@ -99,7 +99,7 @@ export default function PackageDisplaySection({
               onChange={handleChange}
               placeholder="3b82f6"
               maxLength={7}
-              className="flex-1 px-4 py-2.5 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all font-mono text-sm"
+              className="flex-1 px-4 py-2.5 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all font-mono text-sm"
             />
             <div 
               className="w-12 h-12 rounded-xl border-2 border-neutral-300 dark:border-neutral-600 shadow-sm"
@@ -122,7 +122,7 @@ export default function PackageDisplaySection({
               onChange={handleChange}
               min="0"
               placeholder="0"
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all"
             />
           </div>
 
@@ -138,7 +138,7 @@ export default function PackageDisplaySection({
               onChange={handleChange}
               placeholder="🎂"
               maxLength={4}
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all text-2xl text-center"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all text-2xl text-center"
             />
           </div>
 
@@ -154,7 +154,7 @@ export default function PackageDisplaySection({
               onChange={handleChange}
               placeholder="BESTSELLER"
               maxLength={20}
-              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all uppercase"
+              className="w-full px-4 py-3 border border-neutral-300 dark:border-neutral-600 rounded-xl bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent transition-all uppercase"
             />
           </div>
         </div>

--- a/apps/frontend/components/queue/add-to-queue-form.tsx
+++ b/apps/frontend/components/queue/add-to-queue-form.tsx
@@ -251,9 +251,8 @@ export function AddToQueueForm({ clients, onSubmit, onCancel, onClientAdded }: A
                     </FormControl>
                   </PopoverTrigger>
                   <PopoverContent
-                    className="w-auto p-0 bg-white dark:bg-neutral-800"
+                    className="w-auto p-0 bg-white dark:bg-neutral-800 z-[9999]"
                     align="start"
-                    style={{ zIndex: 9999 }}
                   >
                     <Calendar
                       mode="single"

--- a/apps/frontend/components/queue/edit-queue-form.tsx
+++ b/apps/frontend/components/queue/edit-queue-form.tsx
@@ -141,9 +141,8 @@ export function EditQueueForm({ queueItem, clients, onSubmit, onCancel }: EditQu
                   </FormControl>
                 </PopoverTrigger>
                 <PopoverContent
-                  className="w-auto p-0 bg-white dark:bg-neutral-800"
+                  className="w-auto p-0 bg-white dark:bg-neutral-800 z-[9999]"
                   align="start"
-                  style={{ zIndex: 9999 }}
                 >
                   <Calendar
                     mode="single"

--- a/apps/frontend/components/reservations/editable/EditableInternalNotesCard.tsx
+++ b/apps/frontend/components/reservations/editable/EditableInternalNotesCard.tsx
@@ -84,7 +84,7 @@ export function EditableInternalNotesCard({
           value={notes}
           onChange={(e) => handleChange(e.target.value)}
           readOnly={disabled}
-          className={`w-full rounded-xl border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-black/20 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-violet-500 hover:border-violet-400 transition-colors resize-none${disabled ? ' opacity-60 cursor-not-allowed' : ''}`}
+          className={`w-full rounded-xl border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-black/20 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring hover:border-violet-400 transition-colors resize-none${disabled ? ' opacity-60 cursor-not-allowed' : ''}`}
           rows={3}
           placeholder="Wewnętrzne uwagi, preferencje klienta, info dla zespołu..."
         />

--- a/apps/frontend/components/service-extras/ReservationExtrasPanel.tsx
+++ b/apps/frontend/components/service-extras/ReservationExtrasPanel.tsx
@@ -296,7 +296,7 @@ export function ReservationExtrasPanel({ reservationId, readOnly = false }: Rese
                                 onKeyDown={(e) => handleNoteKeyDown(e, extra.id)}
                                 placeholder="Wpisz notatkę..."
                                 rows={2}
-                                className="w-full text-xs px-2.5 py-1.5 rounded-md border border-violet-300 dark:border-violet-700 bg-violet-50/50 dark:bg-violet-900/20 focus:outline-none focus:ring-2 focus:ring-violet-400 focus:border-transparent resize-none placeholder:text-violet-400 dark:placeholder:text-violet-600"
+                                className="w-full text-xs px-2.5 py-1.5 rounded-md border border-violet-300 dark:border-violet-700 bg-violet-50/50 dark:bg-violet-900/20 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent resize-none placeholder:text-violet-400 dark:placeholder:text-violet-600"
                               />
                               <div className="flex items-center gap-1.5">
                                 <button

--- a/apps/frontend/components/ui/toaster.tsx
+++ b/apps/frontend/components/ui/toaster.tsx
@@ -17,11 +17,9 @@ export function Toaster() {
         style: {
           padding: '16px',
           borderRadius: '12px',
-          fontSize: '14px',
           boxShadow: '0 10px 40px rgba(0, 0, 0, 0.1)',
-          zIndex: 99999,
         },
-        className: 'backdrop-blur-sm',
+        className: 'backdrop-blur-sm z-[99999] text-sm',
       }}
     />
   )


### PR DESCRIPTION
## Summary
Dokończenie pozostałych zadań z EPIC #233 (Premium UI/UX polish) i #232 (Catering UI/UX unifikacja).

### EPIC #233 — Premium UI/UX polish
- **gray→neutral**: SessionTimeoutModal (14 instancji) + delete-client-modal (5 instancji)
- **Focus ring standaryzacja**: 28 custom `focus:ring-blue/violet/indigo-*` → `focus:ring-ring` w 11 plikach
- **Inline styles→Tailwind**: zIndex inline → `z-[*]`, fontSize inline → `text-[*]` (4 pliki)
- **not-found.tsx**: pełny dark mode + blue→violet (brand color)

### EPIC #232 — Catering UI/UX unifikacja
- **moduleAccents**: inline `CATERING_ACCENT` → `moduleAccents.catering` (orders + templates)
- **Shared components**: raw `<Loader2>` → `<LoadingState>`, custom empty → `<EmptyState>`
- **OrderHeader**: hardcoded gradient → `moduleAccents.catering.gradient`
- **Order edit**: LoadingState + moduleAccents gradient

## Test plan
- [ ] SessionTimeoutModal — weryfikacja wizualna w dark mode (brak gray, same neutral)
- [ ] not-found.tsx — dark mode działa, przycisk violet
- [ ] Focus rings — jednolity kolor fokusa we wszystkich formularzach
- [ ] Catering orders — LoadingState i EmptyState wyświetlają się poprawnie
- [ ] Catering detail/edit — gradient z moduleAccents, brak raw Loader2

🤖 Generated with [Claude Code](https://claude.com/claude-code)