### PR TITLE
fix(clients): napraw hydration error — zagnieżdżone <a> w <Link>

### DIFF
--- a/apps/frontend/components/clients/clients-list.tsx
+++ b/apps/frontend/components/clients/clients-list.tsx
@@ -165,24 +165,32 @@ export function ClientsList({ clients, searchQuery, rodoMap = {} }: ClientsListP
                     {/* Contact details */}
                     <div className="flex flex-wrap items-center gap-3 text-sm text-neutral-500 dark:text-neutral-400">
                       {client.email && !isDeleted && (
-                        <a
-                          href={`mailto:${client.email}`}
-                          className="flex items-center gap-1 hover:text-primary transition-colors"
-                          onClick={(e) => e.stopPropagation()}
+                        <span
+                          role="link"
+                          className="flex items-center gap-1 hover:text-primary transition-colors cursor-pointer"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            window.location.href = `mailto:${client.email}`
+                          }}
                         >
                           <Mail className="h-3 w-3" />
                           <span>{client.email}</span>
-                        </a>
+                        </span>
                       )}
                       {!isDeleted && (
-                        <a
-                          href={`tel:${client.phone}`}
-                          className="flex items-center gap-1 hover:text-primary transition-colors"
-                          onClick={(e) => e.stopPropagation()}
+                        <span
+                          role="link"
+                          className="flex items-center gap-1 hover:text-primary transition-colors cursor-pointer"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            window.location.href = `tel:${client.phone}`
+                          }}
                         >
                           <Phone className="h-3 w-3" />
                           <span>{client.phone}</span>
-                        </a>
+                        </span>
                       )}
                       {!isDeleted && isCompany && client.nip && (
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Naprawia błąd hydration React spowodowany zagnieżdżeniem `<a href="mailto:">` i `<a href="tel:">` wewnątrz Next.js `<Link>` (który sam renderuje `<a>`)
- Zamiana na `<span role="link" onClick={...}>` z `window.location.href` zachowuje funkcjonalność bez naruszania HTML spec

## Test plan
- [ ] Sprawdzić brak błędów hydration w konsoli na stronie klientów
- [ ] Kliknięcie email otwiera mailto:
- [ ] Kliknięcie telefonu otwiera tel:
- [ ] Kliknięcie całej karty nadal nawiguje do szczegółów klienta

🤖 Generated with [Claude Code](https://claude.com/claude-code)