### PR TITLE
feat(ux): #457 ujednolicenie wizualne kart — gradient-card pattern

### DIFF
--- a/apps/frontend/app/dashboard/clients/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/clients/[id]/page.tsx
@@ -198,18 +198,16 @@ export default function ClientDetailsPage() {
               )}
 
               {client.notes && (
-                <Card className="border-0 shadow-xl">
-                  <CardHeader className="border-b">
-                    <CardTitle className="flex items-center gap-2">
-                      <div className="p-2 bg-gradient-to-br from-orange-500 to-amber-500 rounded-lg">
+                <Card className="border-0 shadow-xl overflow-hidden">
+                  <div className="bg-gradient-to-br from-orange-50 via-amber-50 to-yellow-50 dark:from-orange-950/30 dark:via-amber-950/30 dark:to-yellow-950/30 p-6">
+                    <div className="flex items-center gap-3 mb-4">
+                      <div className="p-2 bg-gradient-to-br from-orange-500 to-amber-500 rounded-lg shadow-lg">
                         <FileText className="h-5 w-5 text-white" />
                       </div>
-                      Notatki
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="p-6">
+                      <h2 className="text-xl font-bold">Notatki</h2>
+                    </div>
                     <p className="text-muted-foreground leading-relaxed">{client.notes}</p>
-                  </CardContent>
+                  </div>
                 </Card>
               )}
 

--- a/apps/frontend/app/dashboard/event-types/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/event-types/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { ArrowLeft, Edit, Trash2, Calendar, FileText, Theater, CheckCircle2, Clock, Timer } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { LoadingState } from '@/components/shared/LoadingState'
 import { Switch } from '@/components/ui/switch'
@@ -181,16 +181,14 @@ export default function EventTypeDetailPage() {
         {/* Details Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {/* Info Card */}
-          <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <div className="p-2 bg-gradient-to-br from-fuchsia-500 to-pink-500 rounded-lg">
+          <Card className="border-0 shadow-xl overflow-hidden">
+            <div className="bg-gradient-to-br from-neutral-800/5 via-slate-700/5 to-neutral-800/5 dark:from-neutral-800/10 dark:via-slate-700/10 dark:to-neutral-800/10 p-6">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2 bg-gradient-to-br from-fuchsia-500 to-pink-500 rounded-lg shadow-lg">
                   <Theater className="h-5 w-5 text-white" />
                 </div>
-                Informacje
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+                <h2 className="text-xl font-bold">Informacje</h2>
+              </div>
               <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
                 <div className="flex justify-between items-center py-3">
                   <span className="text-sm text-muted-foreground">Nazwa</span>
@@ -234,20 +232,18 @@ export default function EventTypeDetailPage() {
                   <span className="font-medium text-sm">{updatedDate}</span>
                 </div>
               </div>
-            </CardContent>
+            </div>
           </Card>
 
           {/* Pricing / Extra Hours Card */}
-          <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <div className="p-2 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg">
+          <Card className="border-0 shadow-xl overflow-hidden">
+            <div className="bg-gradient-to-br from-neutral-800/5 via-slate-700/5 to-neutral-800/5 dark:from-neutral-800/10 dark:via-slate-700/10 dark:to-neutral-800/10 p-6">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg shadow-lg">
                   <Timer className="h-5 w-5 text-white" />
                 </div>
-                Czas &amp; dodatkowe godziny
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+                <h2 className="text-xl font-bold">Czas &amp; dodatkowe godziny</h2>
+              </div>
               <div className="space-y-4">
                 {/* Standard hours */}
                 <div className="rounded-xl bg-gradient-to-br from-blue-500/5 to-cyan-500/5 border border-blue-100 dark:border-blue-900/30 p-5">
@@ -296,20 +292,18 @@ export default function EventTypeDetailPage() {
                   </div>
                 </div>
               </div>
-            </CardContent>
+            </div>
           </Card>
 
           {/* Relations Card */}
-          <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow md:col-span-2">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <div className="p-2 bg-gradient-to-br from-violet-500 to-purple-500 rounded-lg">
+          <Card className="border-0 shadow-xl overflow-hidden md:col-span-2">
+            <div className="bg-gradient-to-br from-neutral-800/5 via-slate-700/5 to-neutral-800/5 dark:from-neutral-800/10 dark:via-slate-700/10 dark:to-neutral-800/10 p-6">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="p-2 bg-gradient-to-br from-violet-500 to-purple-500 rounded-lg shadow-lg">
                   <Calendar className="h-5 w-5 text-white" />
                 </div>
-                Powiązania
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
+                <h2 className="text-xl font-bold">Powiązania</h2>
+              </div>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {/* Reservations */}
                 <div className="rounded-xl bg-gradient-to-br from-violet-500/5 to-purple-500/5 border border-violet-100 dark:border-violet-900/30 p-5">
@@ -365,7 +359,7 @@ export default function EventTypeDetailPage() {
                   </p>
                 </div>
               )}
-            </CardContent>
+            </div>
           </Card>
         </div>
       </div>

--- a/apps/frontend/app/dashboard/halls/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/halls/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { Edit, Calendar, Users, Sparkles, CheckCircle2, Building2, UsersRound, UserCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { getHallById, type Hall } from '@/lib/api/halls'
 import { HallReservationsCalendar } from '@/components/halls/hall-reservations-calendar'
@@ -109,33 +109,29 @@ export default function HallDetailsPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {/* Description */}
           {hall.description && (
-            <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <div className="p-2 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg">
+            <Card className="border-0 shadow-xl overflow-hidden">
+              <div className="bg-gradient-to-br from-neutral-800/5 via-slate-700/5 to-neutral-800/5 dark:from-neutral-800/10 dark:via-slate-700/10 dark:to-neutral-800/10 p-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="p-2 bg-gradient-to-br from-blue-500 to-cyan-500 rounded-lg shadow-lg">
                     <Sparkles className="h-5 w-5 text-white" />
                   </div>
-                  Opis
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+                  <h2 className="text-xl font-bold">Opis</h2>
+                </div>
                 <p className="text-muted-foreground leading-relaxed">{hall.description}</p>
-              </CardContent>
+              </div>
             </Card>
           )}
 
           {/* Amenities */}
           {hall.amenities && hall.amenities.length > 0 && (
-            <Card className="border-0 shadow-lg hover:shadow-xl transition-shadow">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <div className="p-2 bg-gradient-to-br from-purple-500 to-pink-500 rounded-lg">
+            <Card className="border-0 shadow-xl overflow-hidden">
+              <div className="bg-gradient-to-br from-neutral-800/5 via-slate-700/5 to-neutral-800/5 dark:from-neutral-800/10 dark:via-slate-700/10 dark:to-neutral-800/10 p-6">
+                <div className="flex items-center gap-3 mb-4">
+                  <div className="p-2 bg-gradient-to-br from-purple-500 to-pink-500 rounded-lg shadow-lg">
                     <CheckCircle2 className="h-5 w-5 text-white" />
                   </div>
-                  Udogodnienia
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+                  <h2 className="text-xl font-bold">Udogodnienia</h2>
+                </div>
                 <div className="flex flex-wrap gap-2">
                   {hall.amenities.map((amenity, idx) => (
                     <Badge
@@ -146,7 +142,7 @@ export default function HallDetailsPage() {
                     </Badge>
                   ))}
                 </div>
-              </CardContent>
+              </div>
             </Card>
           )}
         </div>

--- a/apps/frontend/components/attachments/attachment-panel.tsx
+++ b/apps/frontend/components/attachments/attachment-panel.tsx
@@ -55,7 +55,7 @@ export default function AttachmentPanel({
   return (
     <div className={cn('rounded-2xl border border-neutral-200/80 dark:border-neutral-700/50 bg-white dark:bg-neutral-800/80', className)}>
       {/* Header */}
-      <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-200/80 dark:border-neutral-700/50">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-neutral-200/80 dark:border-neutral-700/50 bg-gradient-to-r from-violet-50 to-purple-50 dark:from-violet-950/20 dark:to-purple-950/20">
         <div className="flex items-center gap-2.5">
           <div className="w-8 h-8 rounded-lg bg-violet-100 dark:bg-violet-900/30 flex items-center justify-center">
             <Paperclip className="w-4 h-4 text-violet-600 dark:text-violet-400" />


### PR DESCRIPTION
## Summary
- halls/[id]: karty Opis + Udogodnienia → shadow-xl, overflow-hidden, gradient header (slate)
- event-types/[id]: karty Informacje + Czas + Powiązania → jw.
- clients/[id]: karta Notatki → orange gradient header
- attachment-panel: gradient strip w headerze (violet-to-purple)
- Usunięte CardHeader/CardTitle (shadcn) → inline div pattern spójny z resztą systemu

## Test plan
- [ ] Karty w halls/[id] mają gradient header + shadow-xl
- [ ] Karty w event-types/[id] mają gradient header + shadow-xl
- [ ] Karta Notatki w clients/[id] ma orange gradient
- [ ] Attachment panel ma violet gradient strip w headerze
- [ ] Dark mode zachowuje poprawne kolory

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)