### PR TITLE
fix(ux): unifikacja kart rezerwacji + tooltip truncation

### DIFF
--- a/apps/frontend/app/dashboard/reservations/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/[id]/page.tsx
@@ -29,6 +29,7 @@ import { EntityActivityTimeline } from '@/components/audit-log/EntityActivityTim
 import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
+import { GradientCard } from '@/components/shared/GradientCard'
 import { ReservationTimeline } from '@/components/reservations/ReservationTimeline'
 import { ReservationHero } from './components/ReservationHero'
 import { QuickActionsCard } from './components/QuickActionsCard'
@@ -266,45 +267,42 @@ export default function ReservationDetailsPage() {
             {/* Left Column - Main Info */}
             <div className="lg:col-span-2 space-y-6">
               {/* Client Info (read-only) */}
-              <Card className="shadow-sm border border-border">
-                <div className="bg-card p-4 sm:p-6 lg:p-8">
-                  <div className="flex items-center gap-3 mb-5 sm:mb-6">
-                    <div className="p-2 bg-gradient-to-br from-blue-600 to-blue-800 rounded-lg shadow-sm">
-                      <User className="h-5 w-5 text-white" />
+              <GradientCard
+                title="Klient"
+                icon={<User className="h-5 w-5 text-white" />}
+                iconGradient="from-blue-600 to-indigo-600"
+                headerGradient="from-blue-50 via-indigo-50 to-purple-50 dark:from-blue-950/30 dark:via-indigo-950/30 dark:to-purple-950/30"
+              >
+                <div className="space-y-4">
+                  <div className="flex items-center gap-3">
+                    <User className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-sm text-muted-foreground">Imię i nazwisko</p>
+                      <p className="text-base sm:text-lg font-semibold truncate">
+                        {reservation.client?.firstName} {reservation.client?.lastName}
+                      </p>
                     </div>
-                    <h2 className="text-xl sm:text-2xl font-bold">Klient</h2>
                   </div>
-                  <div className="space-y-4">
+                  {reservation.client?.email && (
                     <div className="flex items-center gap-3">
-                      <User className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                      <Mail className="h-5 w-5 text-muted-foreground flex-shrink-0" />
                       <div className="min-w-0">
-                        <p className="text-sm text-muted-foreground">Imię i nazwisko</p>
-                        <p className="text-base sm:text-lg font-semibold truncate">
-                          {reservation.client?.firstName} {reservation.client?.lastName}
-                        </p>
+                        <p className="text-sm text-muted-foreground">Email</p>
+                        <p className="text-base sm:text-lg font-semibold truncate">{reservation.client.email}</p>
                       </div>
                     </div>
-                    {reservation.client?.email && (
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-                        <div className="min-w-0">
-                          <p className="text-sm text-muted-foreground">Email</p>
-                          <p className="text-base sm:text-lg font-semibold truncate">{reservation.client.email}</p>
-                        </div>
+                  )}
+                  {reservation.client?.phone && (
+                    <div className="flex items-center gap-3">
+                      <Phone className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                      <div className="min-w-0">
+                        <p className="text-sm text-muted-foreground">Telefon</p>
+                        <p className="text-base sm:text-lg font-semibold">{reservation.client.phone}</p>
                       </div>
-                    )}
-                    {reservation.client?.phone && (
-                      <div className="flex items-center gap-3">
-                        <Phone className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-                        <div className="min-w-0">
-                          <p className="text-sm text-muted-foreground">Telefon</p>
-                          <p className="text-base sm:text-lg font-semibold">{reservation.client.phone}</p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                    </div>
+                  )}
                 </div>
-              </Card>
+              </GradientCard>
 
               {/* Hall Info */}
               <EditableHallCard

--- a/apps/frontend/components/reservations/ReservationMenuSection.tsx
+++ b/apps/frontend/components/reservations/ReservationMenuSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { GradientCard } from '@/components/shared/GradientCard'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -141,40 +141,35 @@ export function ReservationMenuSection({
     <>
       {/* No menu selected */}
       {!hasMenu && (
-        <Card className="border-0 shadow-xl">
-          <CardHeader className="border-b">
-            <CardTitle className="flex items-center gap-2">
-              <div className="p-2 bg-gradient-to-br from-orange-500 to-amber-500 rounded-lg">
-                <UtensilsCrossed className="h-5 w-5 text-white" />
-              </div>
-              Menu
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-6">
-            <div className="text-center py-8 space-y-4">
-              <div className="w-16 h-16 bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-950/50 dark:to-amber-950/50 rounded-full flex items-center justify-center mx-auto">
-                <UtensilsCrossed className="h-8 w-8 text-orange-600 dark:text-orange-400" />
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold">Brak wybranego menu</h3>
-                <p className="text-sm text-muted-foreground mt-1">
-                  {readOnly
-                    ? 'Menu nie zostało przypisane do tej rezerwacji'
-                    : 'Dodaj menu do rezerwacji aby zobaczyć szczegóły'}
-                </p>
-              </div>
-              {!readOnly && (
-                <Button
-                  onClick={() => setShowSelectionDialog(true)}
-                  className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600"
-                >
-                  <Plus className="mr-2 h-4 w-4" />
-                  Dodaj menu
-                </Button>
-              )}
+        <GradientCard
+          title="Menu"
+          icon={<UtensilsCrossed className="h-5 w-5 text-white" />}
+          iconGradient="from-orange-500 to-amber-500"
+          headerGradient="from-orange-50 via-amber-50 to-yellow-50 dark:from-orange-950/30 dark:via-amber-950/30 dark:to-yellow-950/30"
+        >
+          <div className="text-center py-8 space-y-4">
+            <div className="w-16 h-16 bg-gradient-to-br from-orange-100 to-amber-100 dark:from-orange-950/50 dark:to-amber-950/50 rounded-full flex items-center justify-center mx-auto">
+              <UtensilsCrossed className="h-8 w-8 text-orange-600 dark:text-orange-400" />
             </div>
-          </CardContent>
-        </Card>
+            <div>
+              <h3 className="text-lg font-semibold">Brak wybranego menu</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                {readOnly
+                  ? 'Menu nie zostało przypisane do tej rezerwacji'
+                  : 'Dodaj menu do rezerwacji aby zobaczyć szczegóły'}
+              </p>
+            </div>
+            {!readOnly && (
+              <Button
+                onClick={() => setShowSelectionDialog(true)}
+                className="bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600"
+              >
+                <Plus className="mr-2 h-4 w-4" />
+                Dodaj menu
+              </Button>
+            )}
+          </div>
+        </GradientCard>
       )}
 
       {/* Menu selected - compact view */}

--- a/apps/frontend/components/reservations/editable/EditableEventCard.tsx
+++ b/apps/frontend/components/reservations/editable/EditableEventCard.tsx
@@ -188,6 +188,8 @@ export function EditableEventCard({
       title="Szczegóły wydarzenia"
       icon={<Sparkles className="h-5 w-5 text-white" />}
       iconGradient="from-green-500 to-emerald-500"
+      gradientHeader
+      headerGradient="bg-gradient-to-br from-green-50 via-emerald-50 to-teal-50 dark:from-green-950/30 dark:via-emerald-950/30 dark:to-teal-950/30"
       onSave={handleSave}
       onCancel={handleCancel}
       disabled={disabled}

--- a/apps/frontend/components/reservations/editable/EditableHallCard.tsx
+++ b/apps/frontend/components/reservations/editable/EditableHallCard.tsx
@@ -185,7 +185,9 @@ export function EditableHallCard({
     <EditableCard
       title="Sala"
       icon={<Building2 className="h-5 w-5 text-white" />}
-      iconGradient="from-purple-500 to-pink-500"
+      iconGradient="from-blue-500 to-cyan-500"
+      gradientHeader
+      headerGradient="bg-gradient-to-br from-blue-50 via-cyan-50 to-teal-50 dark:from-blue-950/30 dark:via-cyan-950/30 dark:to-teal-950/30"
       onSave={handleSave}
       onCancel={handleCancel}
       disabled={disabled}

--- a/apps/frontend/components/reservations/reservation-list/ReservationCard.tsx
+++ b/apps/frontend/components/reservations/reservation-list/ReservationCard.tsx
@@ -50,9 +50,9 @@ export function ReservationCard({
   const isPdfGenerating = generatingPdfId === reservation.id
 
   return (
-    <div className="rounded-2xl bg-white dark:bg-neutral-800/80 border border-neutral-200/80 dark:border-neutral-700/50 shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1 overflow-hidden active:scale-[0.99]">
+    <div className="rounded-2xl bg-white dark:bg-neutral-800/80 border border-neutral-200/80 dark:border-neutral-700/50 shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1 active:scale-[0.99]">
       <div className={cn(
-        'p-4 sm:p-6',
+        'p-4 sm:p-6 rounded-t-2xl overflow-hidden',
         `bg-gradient-to-r ${accent.gradientSubtle}`
       )}>
         {/* Header: Time + Status + Badges */}


### PR DESCRIPTION
## Summary
- **Karty rezerwacji** — 4 karty zmigrowane na gradient header pattern (spójne z referencyjną "Goście"):
  - EditableHallCard: `gradientHeader` + blue/cyan
  - EditableEventCard: `gradientHeader` + green/emerald
  - Klient: raw Card → `GradientCard` (blue/indigo)
  - Menu empty state: `CardHeader`/`border-b` → `GradientCard` (orange/amber)
- **Tooltip fix** — `overflow-hidden` przeniesiony z outer div karty rezerwacji na inner gradient div, tooltipki na ikonach akcji nie są już ucinane

## Test plan
- [ ] Wizualnie: wszystkie karty na `/dashboard/reservations/[id]` mają gradient header
- [ ] Tooltipki na liście rezerwacji widoczne w całości po najechaniu na ikony
- [ ] Dark mode zachowuje poprawne kolory
- [ ] Component tests przechodzą

🤖 Generated with [Claude Code](https://claude.com/claude-code)