### PR TITLE
fix(ux): pełna unifikacja wizualna — stat cards + spójność kart (#468)

### DIFF
--- a/apps/frontend/app/dashboard/clients/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/clients/[id]/page.tsx
@@ -207,7 +207,9 @@ export default function ClientDetailsPage() {
                       </div>
                       <h2 className="text-xl font-bold">Notatki</h2>
                     </div>
-                    <p className="text-muted-foreground leading-relaxed">{client.notes}</p>
+                    <div className="p-3 bg-white dark:bg-black/20 rounded-lg">
+                      <p className="text-muted-foreground leading-relaxed">{client.notes}</p>
+                    </div>
                   </div>
                 </Card>
               )}

--- a/apps/frontend/app/dashboard/event-types/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/event-types/[id]/page.tsx
@@ -191,16 +191,16 @@ export default function EventTypeDetailPage() {
                 </div>
                 <h2 className="text-xl font-bold">Informacje</h2>
               </div>
-              <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
-                <div className="flex justify-between items-center py-3">
+              <div className="space-y-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Nazwa</span>
                   <span className="font-semibold">{eventType.name}</span>
                 </div>
-                <div className="flex justify-between items-center py-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Opis</span>
                   <span className="font-medium text-right max-w-[60%] text-sm">{eventType.description || '\u2014'}</span>
                 </div>
-                <div className="flex justify-between items-center py-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Kolor</span>
                   <div className="flex items-center gap-2">
                     <div
@@ -212,7 +212,7 @@ export default function EventTypeDetailPage() {
                     <span className="font-mono text-sm text-muted-foreground">{eventType.color || 'Brak'}</span>
                   </div>
                 </div>
-                <div className="flex justify-between items-center py-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Status</span>
                   <div className="flex items-center gap-3">
                     <Badge variant={eventType.isActive ? 'default' : 'secondary'}>
@@ -225,11 +225,11 @@ export default function EventTypeDetailPage() {
                     />
                   </div>
                 </div>
-                <div className="flex justify-between items-center py-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Utworzony</span>
                   <span className="font-medium text-sm">{createdDate}</span>
                 </div>
-                <div className="flex justify-between items-center py-3">
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg flex justify-between items-center">
                   <span className="text-sm text-muted-foreground">Aktualizacja</span>
                   <span className="font-medium text-sm">{updatedDate}</span>
                 </div>

--- a/apps/frontend/app/dashboard/halls/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/halls/[id]/page.tsx
@@ -119,7 +119,9 @@ export default function HallDetailsPage() {
                   </div>
                   <h2 className="text-xl font-bold">Opis</h2>
                 </div>
-                <p className="text-muted-foreground leading-relaxed">{hall.description}</p>
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg">
+                  <p className="text-muted-foreground leading-relaxed">{hall.description}</p>
+                </div>
               </div>
             </Card>
           )}
@@ -134,15 +136,17 @@ export default function HallDetailsPage() {
                   </div>
                   <h2 className="text-xl font-bold">Udogodnienia</h2>
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  {hall.amenities.map((amenity, idx) => (
-                    <Badge
-                      key={idx}
-                      className="text-sm py-2 px-3 border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950/50 text-purple-700 dark:text-purple-300"
-                    >
-                      {amenity}
-                    </Badge>
-                  ))}
+                <div className="p-3 bg-white dark:bg-black/20 rounded-lg">
+                  <div className="flex flex-wrap gap-2">
+                    {hall.amenities.map((amenity, idx) => (
+                      <Badge
+                        key={idx}
+                        className="text-sm py-2 px-3 border border-purple-200 dark:border-purple-800 bg-purple-50 dark:bg-purple-950/50 text-purple-700 dark:text-purple-300"
+                      >
+                        {amenity}
+                      </Badge>
+                    ))}
+                  </div>
                 </div>
               </div>
             </Card>

--- a/apps/frontend/app/dashboard/menu/packages/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/menu/packages/[id]/page.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import { Package } from 'lucide-react';
 import PackageForm from '@/components/menu/PackageForm';
 import { getPackageById, type MenuPackage } from '@/lib/api/menu-packages-api';
 import { LoadingState } from '@/components/shared/LoadingState';
+import { DetailHero } from '@/components/shared/DetailHero';
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
 
 export default function EditPackagePage() {
@@ -59,14 +61,16 @@ export default function EditPackagePage() {
   }
 
   return (
-    <div className="p-8">
-      <Breadcrumb />
-
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-neutral-900">Edytuj pakiet</h1>
-        <p className="text-neutral-600 mt-2">{pkg.name}</p>
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20">
+      <div className="container mx-auto py-8 px-4 space-y-8">
+        <DetailHero
+          gradient="from-amber-600 via-orange-600 to-yellow-600"
+          backHref="/dashboard/menu/packages"
+          backLabel="Powrót do pakietów"
+          icon={Package}
+          title={pkg.name}
+          subtitle="Edycja pakietu menu"
+        />
 
       {/* Form */}
       <PackageForm
@@ -76,6 +80,7 @@ export default function EditPackagePage() {
           router.push('/dashboard/menu/packages');
         }}
       />
+      </div>
     </div>
   );
 }

--- a/apps/frontend/components/reservations/financial/TotalsSummary.tsx
+++ b/apps/frontend/components/reservations/financial/TotalsSummary.tsx
@@ -34,40 +34,42 @@ export function TotalsSummary({
   return (
     <>
       {/* TOTAL */}
-      <div className="p-4 bg-gradient-to-r from-emerald-500 to-teal-500 rounded-xl text-white mb-4 shadow-lg">
+      <div className="p-4 bg-white dark:bg-black/20 rounded-xl mb-4 border border-emerald-200 dark:border-emerald-800">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <DollarSign className="h-5 w-5 opacity-80" />
-            <span className="font-bold">Razem do zapłaty</span>
+            <div className="p-1.5 bg-gradient-to-br from-emerald-500 to-teal-500 rounded-lg">
+              <DollarSign className="h-4 w-4 text-white" />
+            </div>
+            <span className="font-bold text-emerald-700 dark:text-emerald-300">Razem do zapłaty</span>
           </div>
-          <span className="text-2xl font-bold" data-testid="final-total-price">{formatCurrency(finalTotalPrice)}</span>
+          <span className="text-2xl font-bold text-emerald-700 dark:text-emerald-300" data-testid="final-total-price">{formatCurrency(finalTotalPrice)}</span>
         </div>
         {hasActiveDiscount && (
-          <div className="flex items-center justify-between mt-1 text-white/80 text-xs">
+          <div className="flex items-center justify-between mt-1 text-muted-foreground text-xs">
             <span>w tym rabat</span>
             <span>-{formatCurrency(activeDiscountAmount)}</span>
           </div>
         )}
         {hasVenueSurcharge && (
-          <div className="flex items-center justify-between mt-1 text-white/80 text-xs">
+          <div className="flex items-center justify-between mt-1 text-muted-foreground text-xs">
             <span>w tym dopłata za cały obiekt</span>
             <span>+{formatCurrency(effectiveVenueSurcharge)}</span>
           </div>
         )}
         {extrasTotalPrice > 0 && (
-          <div className="flex items-center justify-between mt-1 text-white/80 text-xs">
+          <div className="flex items-center justify-between mt-1 text-muted-foreground text-xs">
             <span>w tym usługi dodatkowe ({activeExtrasCount})</span>
             <span>+{formatCurrency(extrasTotalPrice)}</span>
           </div>
         )}
         {effectiveCategoryExtrasTotal > 0 && (
-          <div className="flex items-center justify-between mt-1 text-white/80 text-xs">
+          <div className="flex items-center justify-between mt-1 text-muted-foreground text-xs">
             <span>w tym dodatkowo płatne porcje ({activeCategoryExtrasCount})</span>
             <span>+{formatCurrency(effectiveCategoryExtrasTotal)}</span>
           </div>
         )}
         {extraHoursInfo && extraHoursInfo.extraCost > 0 && (
-          <div className="flex items-center justify-between mt-1 text-white/80 text-xs">
+          <div className="flex items-center justify-between mt-1 text-muted-foreground text-xs">
             <span>w tym dopłata za {extraHoursInfo.extraHours} dodatkow{extraHoursInfo.extraHours === 1 ? 'ą godzinę' : extraHoursInfo.extraHours < 5 ? 'e godziny' : 'ych godzin'}</span>
             <span>+{formatCurrency(extraHoursInfo.extraCost)}</span>
           </div>


### PR DESCRIPTION
## Summary

Fixes #469, fixes #470, fixes #471, fixes #472, fixes #473

- **Halls [id]**: opis i udogodnienia opakowane w stat cards (`bg-white dark:bg-black/20 rounded-lg`)
- **Event types [id]**: zamiana `divide-y` na `space-y-3` z stat cards w karcie Informacje
- **Menu packages [id]**: dodanie `DetailHero` (amber/orange gradient) zamiast prostego `<h1>`
- **Clients [id]**: treść notatek opakowana w stat card
- **TotalsSummary**: zamiana gradient bar "Razem do zapłaty" na spójny stat card z emerald border — uproszczenie palety kolorów
- **Catering orders**: zaudytowane — `OrderHeader` i `OrderFinancials` już spójne, bez zmian
- **EditableCard**: non-gradient branch zachowany jako fallback
- **Attachment panel**: spójny z GradientCard pattern, bez zmian

## Audyt wyników
| Moduł | Issue | Status |
|-------|-------|--------|
| Halls szczegóły | #469 | ✅ naprawione |
| Event types szczegóły | #470 | ✅ naprawione |
| Menu packages szczegóły | #471 | ✅ naprawione |
| Clients notatki | #472 | ✅ naprawione |
| TotalsSummary | #473 | ✅ naprawione |
| Catering orders | — | ✅ OK (bez zmian) |
| EditableCard | — | ✅ zaudytowane |
| Attachment panel | — | ✅ OK (bez zmian) |

## Test plan
- [x] TypeScript kompilacja (`tsc --noEmit`) — OK
- [x] Vitest frontend — 109 plików, 1230 testów passed
- [ ] CI pipeline (GitHub Actions)
- [ ] Weryfikacja wizualna na VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)