### PR TITLE
[Premium UI] Etap 8: TabNav + Polish + Responsive + Dark Mode (#541-#544)

### DIFF
--- a/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
+++ b/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Must use vi.hoisted so the mock fn is available before vi.mock runs
 const { mockUseInView } = vi.hoisted(() => ({
   mockUseInView: vi.fn(),
 }))
@@ -13,15 +12,29 @@ vi.mock('framer-motion', () => ({
 import { AnimatedCounter } from '@/components/shared/AnimatedCounter'
 
 describe('AnimatedCounter', () => {
+  let rafCallbacks: FrameRequestCallback[]
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockUseInView.mockReturnValue(true)
-    vi.useFakeTimers()
+    rafCallbacks = []
+    // Mock requestAnimationFrame to capture callbacks
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      rafCallbacks.push(cb)
+      return rafCallbacks.length
+    })
   })
 
   afterEach(() => {
-    vi.useRealTimers()
+    vi.restoreAllMocks()
   })
+
+  /** Flush all queued rAF callbacks with a given timestamp */
+  function flushRAF(timestamp: number) {
+    const cbs = [...rafCallbacks]
+    rafCallbacks = []
+    cbs.forEach((cb) => cb(timestamp))
+  }
 
   it('should render a span element', () => {
     render(<AnimatedCounter value={42} />)
@@ -39,25 +52,47 @@ describe('AnimatedCounter', () => {
     mockUseInView.mockReturnValue(false)
     render(<AnimatedCounter value={100} />)
     expect(screen.getByText('0')).toBeInTheDocument()
+    // No rAF should have been called
+    expect(rafCallbacks.length).toBe(0)
   })
 
-  it('should display the target value after animation completes', async () => {
-    render(<AnimatedCounter value={50} duration={100} />)
+  it('should animate toward target value via requestAnimationFrame', () => {
+    // performance.now returns 0 on first call (start), then we simulate time passing
+    const perfSpy = vi.spyOn(performance, 'now').mockReturnValue(0)
 
-    vi.useRealTimers()
-    await new Promise((r) => setTimeout(r, 200))
+    render(<AnimatedCounter value={100} duration={800} />)
 
-    expect(screen.getByText('50')).toBeInTheDocument()
+    // First rAF was queued when isInView became true
+    expect(rafCallbacks.length).toBe(1)
+
+    // Simulate the first rAF tick at t=0 (start)
+    act(() => flushRAF(0))
+
+    // Value at t=0 should be 0 (progress=0)
+    expect(screen.getByText('0')).toBeInTheDocument()
+
+    // Simulate completion at t=800 (duration)
+    act(() => flushRAF(800))
+
+    // Value should be 100 (progress=1)
+    expect(screen.getByText('100')).toBeInTheDocument()
+
+    perfSpy.mockRestore()
   })
 
-  it('should use formatFn when provided', async () => {
+  it('should use formatFn when provided', () => {
     const formatFn = (n: number) => `${n} zł`
-    render(<AnimatedCounter value={100} duration={50} formatFn={formatFn} />)
 
-    vi.useRealTimers()
-    await new Promise((r) => setTimeout(r, 150))
+    render(<AnimatedCounter value={50} duration={500} formatFn={formatFn} />)
 
-    expect(screen.getByText('100 zł')).toBeInTheDocument()
+    // Initial state with formatFn
+    expect(screen.getByText('0 zł')).toBeInTheDocument()
+
+    // Complete the animation
+    act(() => flushRAF(0))
+    act(() => flushRAF(500))
+
+    expect(screen.getByText('50 zł')).toBeInTheDocument()
   })
 
   it('should handle value of 0', () => {

--- a/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
+++ b/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
@@ -1,8 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-// Mock framer-motion useInView to always return true (element visible)
-const mockUseInView = vi.fn()
+// Must use vi.hoisted so the mock fn is available before vi.mock runs
+const { mockUseInView } = vi.hoisted(() => ({
+  mockUseInView: vi.fn(),
+}))
+
 vi.mock('framer-motion', () => ({
   useInView: mockUseInView,
 }))
@@ -12,9 +15,7 @@ import { AnimatedCounter } from '@/components/shared/AnimatedCounter'
 describe('AnimatedCounter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: element is in view
     mockUseInView.mockReturnValue(true)
-    // Use fake timers for requestAnimationFrame control
     vi.useFakeTimers()
   })
 
@@ -41,10 +42,8 @@ describe('AnimatedCounter', () => {
   })
 
   it('should display the target value after animation completes', async () => {
-    // useInView returns true, animation should start
     render(<AnimatedCounter value={50} duration={100} />)
 
-    // Advance timers to let requestAnimationFrame callbacks fire
     vi.useRealTimers()
     await new Promise((r) => setTimeout(r, 200))
 

--- a/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
+++ b/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock framer-motion useInView to always return true (element visible)
+const mockUseInView = vi.fn()
+vi.mock('framer-motion', () => ({
+  useInView: mockUseInView,
+}))
+
+import { AnimatedCounter } from '@/components/shared/AnimatedCounter'
+
+describe('AnimatedCounter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: element is in view
+    mockUseInView.mockReturnValue(true)
+    // Use fake timers for requestAnimationFrame control
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should render a span element', () => {
+    render(<AnimatedCounter value={42} />)
+    const el = screen.getByText(/\d+/)
+    expect(el.tagName).toBe('SPAN')
+  })
+
+  it('should apply custom className', () => {
+    render(<AnimatedCounter value={10} className="my-class" />)
+    const el = screen.getByText(/\d+/)
+    expect(el.className).toContain('my-class')
+  })
+
+  it('should display 0 when not in view', () => {
+    mockUseInView.mockReturnValue(false)
+    render(<AnimatedCounter value={100} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('should display the target value after animation completes', async () => {
+    // useInView returns true, animation should start
+    render(<AnimatedCounter value={50} duration={100} />)
+
+    // Advance timers to let requestAnimationFrame callbacks fire
+    vi.useRealTimers()
+    await new Promise((r) => setTimeout(r, 200))
+
+    expect(screen.getByText('50')).toBeInTheDocument()
+  })
+
+  it('should use formatFn when provided', async () => {
+    const formatFn = (n: number) => `${n} zł`
+    render(<AnimatedCounter value={100} duration={50} formatFn={formatFn} />)
+
+    vi.useRealTimers()
+    await new Promise((r) => setTimeout(r, 150))
+
+    expect(screen.getByText('100 zł')).toBeInTheDocument()
+  })
+
+  it('should handle value of 0', () => {
+    render(<AnimatedCounter value={0} />)
+    expect(screen.getByText('0')).toBeInTheDocument()
+  })
+
+  it('should call useInView with once: true', () => {
+    render(<AnimatedCounter value={10} />)
+    expect(mockUseInView).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ once: true })
+    )
+  })
+})

--- a/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
+++ b/apps/frontend/__tests__/components/shared/AnimatedCounter.test.tsx
@@ -18,18 +18,18 @@ describe('AnimatedCounter', () => {
     vi.clearAllMocks()
     mockUseInView.mockReturnValue(true)
     rafCallbacks = []
-    // Mock requestAnimationFrame to capture callbacks
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
       rafCallbacks.push(cb)
       return rafCallbacks.length
     })
+    // Pin performance.now to 0 so rAF timestamps are relative to start
+    vi.spyOn(performance, 'now').mockReturnValue(0)
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  /** Flush all queued rAF callbacks with a given timestamp */
   function flushRAF(timestamp: number) {
     const cbs = [...rafCallbacks]
     rafCallbacks = []
@@ -52,32 +52,21 @@ describe('AnimatedCounter', () => {
     mockUseInView.mockReturnValue(false)
     render(<AnimatedCounter value={100} />)
     expect(screen.getByText('0')).toBeInTheDocument()
-    // No rAF should have been called
     expect(rafCallbacks.length).toBe(0)
   })
 
   it('should animate toward target value via requestAnimationFrame', () => {
-    // performance.now returns 0 on first call (start), then we simulate time passing
-    const perfSpy = vi.spyOn(performance, 'now').mockReturnValue(0)
-
     render(<AnimatedCounter value={100} duration={800} />)
 
-    // First rAF was queued when isInView became true
     expect(rafCallbacks.length).toBe(1)
 
-    // Simulate the first rAF tick at t=0 (start)
+    // t=0: progress=0 → value=0
     act(() => flushRAF(0))
-
-    // Value at t=0 should be 0 (progress=0)
     expect(screen.getByText('0')).toBeInTheDocument()
 
-    // Simulate completion at t=800 (duration)
+    // t=800: progress=1 → value=100
     act(() => flushRAF(800))
-
-    // Value should be 100 (progress=1)
     expect(screen.getByText('100')).toBeInTheDocument()
-
-    perfSpy.mockRestore()
   })
 
   it('should use formatFn when provided', () => {
@@ -85,10 +74,10 @@ describe('AnimatedCounter', () => {
 
     render(<AnimatedCounter value={50} duration={500} formatFn={formatFn} />)
 
-    // Initial state with formatFn
+    // Initial state
     expect(screen.getByText('0 zł')).toBeInTheDocument()
 
-    // Complete the animation
+    // Complete the animation: t=0, then t=500 (= duration)
     act(() => flushRAF(0))
     act(() => flushRAF(500))
 

--- a/apps/frontend/__tests__/components/shared/FilterTabs.test.tsx
+++ b/apps/frontend/__tests__/components/shared/FilterTabs.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Calendar, History } from 'lucide-react'
+import { FilterTabs } from '@/components/shared/FilterTabs'
+
+describe('FilterTabs', () => {
+  const baseTabs = [
+    { key: 'a', label: 'Tab A' },
+    { key: 'b', label: 'Tab B' },
+  ]
+
+  it('should render all tab labels', () => {
+    render(<FilterTabs tabs={baseTabs} activeKey="a" onChange={() => {}} />)
+    expect(screen.getByText('Tab A')).toBeInTheDocument()
+    expect(screen.getByText('Tab B')).toBeInTheDocument()
+  })
+
+  it('should call onChange when a tab is clicked', () => {
+    const onChange = vi.fn()
+    render(<FilterTabs tabs={baseTabs} activeKey="a" onChange={onChange} />)
+    fireEvent.click(screen.getByText('Tab B'))
+    expect(onChange).toHaveBeenCalledWith('b')
+  })
+
+  it('should render badge count when provided', () => {
+    const tabs = [{ key: 'x', label: 'Items', count: 5 }]
+    render(<FilterTabs tabs={tabs} activeKey="x" onChange={() => {}} />)
+    expect(screen.getByText('5')).toBeInTheDocument()
+  })
+
+  it('should not render badge when count is 0', () => {
+    const tabs = [{ key: 'x', label: 'Items', count: 0 }]
+    render(<FilterTabs tabs={tabs} activeKey="x" onChange={() => {}} />)
+    expect(screen.queryByText('0')).not.toBeInTheDocument()
+  })
+
+  it('should render icon when provided', () => {
+    const tabs = [
+      { key: 'details', label: 'Details', icon: Calendar },
+      { key: 'history', label: 'History', icon: History },
+    ]
+    const { container } = render(
+      <FilterTabs tabs={tabs} activeKey="details" onChange={() => {}} />
+    )
+    const svgs = container.querySelectorAll('svg')
+    expect(svgs.length).toBe(2)
+  })
+
+  it('should apply full width mode', () => {
+    const { container } = render(
+      <FilterTabs tabs={baseTabs} activeKey="a" onChange={() => {}} width="full" />
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('w-full')
+  })
+
+  it('should apply active style to selected tab', () => {
+    render(<FilterTabs tabs={baseTabs} activeKey="a" onChange={() => {}} />)
+    const activeBtn = screen.getByText('Tab A').closest('button')!
+    expect(activeBtn.className).toContain('bg-white')
+    expect(activeBtn.className).toContain('shadow-sm')
+  })
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <FilterTabs tabs={baseTabs} activeKey="a" onChange={() => {}} className="mt-4" />
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper.className).toContain('mt-4')
+  })
+})

--- a/apps/frontend/__tests__/components/shared/FilterTabs.test.tsx
+++ b/apps/frontend/__tests__/components/shared/FilterTabs.test.tsx
@@ -46,12 +46,13 @@ describe('FilterTabs', () => {
     expect(svgs.length).toBe(2)
   })
 
-  it('should apply full width mode', () => {
+  it('should apply full width mode with sm:w-fit', () => {
     const { container } = render(
       <FilterTabs tabs={baseTabs} activeKey="a" onChange={() => {}} width="full" />
     )
     const wrapper = container.firstChild as HTMLElement
     expect(wrapper.className).toContain('w-full')
+    expect(wrapper.className).toContain('sm:w-fit')
   })
 
   it('should apply active style to selected tab', () => {

--- a/apps/frontend/__tests__/components/shared/GradientDivider.test.tsx
+++ b/apps/frontend/__tests__/components/shared/GradientDivider.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { GradientDivider } from '@/components/shared/GradientDivider'
+
+describe('GradientDivider', () => {
+  it('should render a separator element', () => {
+    const { container } = render(<GradientDivider />)
+    expect(container.querySelector('[role="separator"]')).toBeInTheDocument()
+  })
+
+  it('should apply border accent by default', () => {
+    const { container } = render(<GradientDivider />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('via-border')
+  })
+
+  it('should apply primary accent when specified', () => {
+    const { container } = render(<GradientDivider accent="primary" />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('via-primary/20')
+  })
+
+  it('should apply muted accent when specified', () => {
+    const { container } = render(<GradientDivider accent="muted" />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('via-muted-foreground/15')
+  })
+
+  it('should apply custom className', () => {
+    const { container } = render(<GradientDivider className="my-4" />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('my-4')
+  })
+
+  it('should have h-px and w-full classes', () => {
+    const { container } = render(<GradientDivider />)
+    const el = container.firstChild as HTMLElement
+    expect(el.className).toContain('h-px')
+    expect(el.className).toContain('w-full')
+  })
+})

--- a/apps/frontend/__tests__/components/shared/StatusBadge.test.tsx
+++ b/apps/frontend/__tests__/components/shared/StatusBadge.test.tsx
@@ -66,9 +66,12 @@ describe('StatusBadge', () => {
     expect(screen.queryByText('CONFIRMED-label')).not.toBeInTheDocument()
   })
 
-  it('should show icon in dot variant when showIcon is true', () => {
-    render(<StatusBadge type="reservation" status="CONFIRMED" variant="dot" showIcon />)
-    expect(screen.getByTestId('status-icon')).toBeInTheDocument()
+  it('should render dot element in dot variant', () => {
+    const { container } = render(
+      <StatusBadge type="reservation" status="COMPLETED" variant="dot" />
+    )
+    const dotEl = container.querySelector('.bg-dot-test')
+    expect(dotEl).toBeInTheDocument()
   })
 
   it('should apply custom className', () => {

--- a/apps/frontend/__tests__/components/shared/StatusBadge.test.tsx
+++ b/apps/frontend/__tests__/components/shared/StatusBadge.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/lib/status-colors', () => ({
+  getStatusConfig: (type: string, status: string) => ({
+    label: `${status}-label`,
+    icon: ({ className }: any) => <span className={className} data-testid="status-icon">icon</span>,
+    bg: 'bg-test',
+    text: 'text-test',
+    border: 'border-test',
+    dot: 'bg-dot-test',
+    solid: 'bg-solid-test text-white',
+  }),
+}))
+
+import { StatusBadge } from '@/components/shared/StatusBadge'
+
+describe('StatusBadge', () => {
+  it('should render default variant with icon and label', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" />)
+    expect(screen.getByText('CONFIRMED-label')).toBeInTheDocument()
+    expect(screen.getByTestId('status-icon')).toBeInTheDocument()
+  })
+
+  it('should render solid variant', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" variant="solid" />)
+    expect(screen.getByText('CONFIRMED-label')).toBeInTheDocument()
+  })
+
+  it('should render dot variant with dot element', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" variant="dot" />)
+    expect(screen.getByText('CONFIRMED-label')).toBeInTheDocument()
+  })
+
+  it('should show ping animation on active statuses in dot variant', () => {
+    const { container } = render(
+      <StatusBadge type="reservation" status="PENDING" variant="dot" />
+    )
+    const pingEl = container.querySelector('.animate-ping')
+    expect(pingEl).toBeInTheDocument()
+  })
+
+  it('should not show ping animation on inactive statuses in dot variant', () => {
+    const { container } = render(
+      <StatusBadge type="reservation" status="COMPLETED" variant="dot" />
+    )
+    const pingEl = container.querySelector('.animate-ping')
+    expect(pingEl).not.toBeInTheDocument()
+  })
+
+  it('should not show ping when ping prop is false', () => {
+    const { container } = render(
+      <StatusBadge type="reservation" status="PENDING" variant="dot" ping={false} />
+    )
+    const pingEl = container.querySelector('.animate-ping')
+    expect(pingEl).not.toBeInTheDocument()
+  })
+
+  it('should hide icon in dot variant by default', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" variant="dot" />)
+    expect(screen.queryByTestId('status-icon')).not.toBeInTheDocument()
+  })
+
+  it('should hide label when showLabel is false', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" showLabel={false} />)
+    expect(screen.queryByText('CONFIRMED-label')).not.toBeInTheDocument()
+  })
+
+  it('should show icon in dot variant when showIcon is true', () => {
+    render(<StatusBadge type="reservation" status="CONFIRMED" variant="dot" showIcon />)
+    expect(screen.getByTestId('status-icon')).toBeInTheDocument()
+  })
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <StatusBadge type="reservation" status="CONFIRMED" className="custom-class" />
+    )
+    expect(container.firstChild).toHaveClass('custom-class')
+  })
+
+  it('should show ping for all active statuses', () => {
+    const activeStatuses = ['PENDING', 'CONFIRMED', 'IN_PREPARATION', 'WAITING', 'DRAFT', 'INQUIRY', 'QUOTED']
+    for (const status of activeStatuses) {
+      const { container, unmount } = render(
+        <StatusBadge type="reservation" status={status} variant="dot" />
+      )
+      expect(container.querySelector('.animate-ping')).toBeInTheDocument()
+      unmount()
+    }
+  })
+})

--- a/apps/frontend/__tests__/pages/ReservationCalendarPage.test.tsx
+++ b/apps/frontend/__tests__/pages/ReservationCalendarPage.test.tsx
@@ -90,6 +90,15 @@ vi.mock('@/components/shared', () => ({
       <span>{value}</span>
     </div>
   ),
+  FilterTabs: ({ tabs, activeKey, onChange }: any) => (
+    <div data-testid="filter-tabs">
+      {tabs.map((t: any) => (
+        <button key={t.key} onClick={() => onChange(t.key)} data-active={t.key === activeKey}>
+          {t.label}
+        </button>
+      ))}
+    </div>
+  ),
   ErrorState: ({ message }: any) => <div data-testid="error-state">{message}</div>,
 }))
 

--- a/apps/frontend/app/dashboard/clients/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/clients/[id]/page.tsx
@@ -28,6 +28,7 @@ import { format } from 'date-fns'
 import { pl } from 'date-fns/locale'
 
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
+import { FilterTabs } from '@/components/shared/FilterTabs'
 import { CompanyInfoCard, ContactInfoCard } from './components/ClientInfoCards'
 import { ClientReservationsHistory } from './components/ClientReservationsHistory'
 
@@ -195,30 +196,15 @@ export default function ClientDetailsPage() {
         </div>
 
         {/* Tab bar */}
-        <div className="flex gap-1 bg-muted/50 p-1 rounded-xl w-full sm:w-fit">
-          <button
-            onClick={() => setActiveTab('details')}
-            className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
-              activeTab === 'details'
-                ? 'bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 shadow-sm'
-                : 'text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-200'
-            }`}
-          >
-            {isCompany ? <Building2 className="h-4 w-4" /> : <User className="h-4 w-4" />}
-            {isCompany ? 'Dane firmy' : 'Dane klienta'}
-          </button>
-          <button
-            onClick={() => setActiveTab('history')}
-            className={`flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
-              activeTab === 'history'
-                ? 'bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 shadow-sm'
-                : 'text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-200'
-            }`}
-          >
-            <History className="h-4 w-4" />
-            Historia zmian
-          </button>
-        </div>
+        <FilterTabs
+          tabs={[
+            { key: 'details', label: isCompany ? 'Dane firmy' : 'Dane klienta', icon: isCompany ? Building2 : User },
+            { key: 'history', label: 'Historia zmian', icon: History },
+          ]}
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as TabType)}
+          width="full"
+        />
 
         {/* Tab: Dane klienta / firmy */}
         {activeTab === 'details' && (

--- a/apps/frontend/app/dashboard/clients/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/clients/[id]/page.tsx
@@ -29,6 +29,7 @@ import { pl } from 'date-fns/locale'
 
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
 import { FilterTabs } from '@/components/shared/FilterTabs'
+import { GradientDivider } from '@/components/shared/GradientDivider'
 import { CompanyInfoCard, ContactInfoCard } from './components/ClientInfoCards'
 import { ClientReservationsHistory } from './components/ClientReservationsHistory'
 
@@ -194,6 +195,8 @@ export default function ClientDetailsPage() {
             iconGradient={statGradients.financial}
           />
         </div>
+
+        <GradientDivider />
 
         {/* Tab bar */}
         <FilterTabs

--- a/apps/frontend/app/dashboard/reports/components/ReportFilters.tsx
+++ b/apps/frontend/app/dashboard/reports/components/ReportFilters.tsx
@@ -21,7 +21,9 @@ export function ReportFilters({
   const showViewToggle = activeTab === 'preparations' || activeTab === 'menu-preparations';
   const currentView = activeTab === 'menu-preparations' ? menuPrepView : prepView;
   const setCurrentView = activeTab === 'menu-preparations' ? setMenuPrepView : setPrepView;
-  const viewColor = activeTab === 'menu-preparations' ? 'amber' : 'purple';
+  const viewActiveClass = activeTab === 'menu-preparations'
+    ? 'bg-amber-600 text-white'
+    : 'bg-purple-600 text-white';
 
   return (
     <div className="bg-white dark:bg-neutral-900 rounded-xl border border-neutral-200 dark:border-neutral-700 p-4">
@@ -44,12 +46,12 @@ export function ReportFilters({
             <div>
               <label className="block text-xs text-neutral-500 dark:text-neutral-300 mb-1">Od</label>
               <input type="date" value={dateFrom} onChange={(e) => setDateFrom(e.target.value)}
-                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500" />
+                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500 dark:focus:border-blue-400" />
             </div>
             <div>
               <label className="block text-xs text-neutral-500 dark:text-neutral-300 mb-1">Do</label>
               <input type="date" value={dateTo} onChange={(e) => setDateTo(e.target.value)}
-                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500" />
+                className="w-full px-3 py-1.5 border border-neutral-300 dark:border-neutral-600 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 rounded-lg text-sm focus:ring-2 focus:ring-ring focus:border-blue-500 dark:focus:border-blue-400" />
             </div>
           </div>
           {activeTab === 'revenue' && (
@@ -73,11 +75,11 @@ export function ReportFilters({
               <label className="block text-xs text-neutral-500 dark:text-neutral-300 mb-1">Widok</label>
               <div className="flex rounded-lg border border-neutral-300 dark:border-neutral-600 overflow-hidden">
                 <button onClick={() => setCurrentView('detailed')}
-                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${currentView === 'detailed' ? `bg-${viewColor}-600 text-white` : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700'}`}>
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${currentView === 'detailed' ? viewActiveClass : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700'}`}>
                   {"Szczegółowy"}
                 </button>
                 <button onClick={() => setCurrentView('summary')}
-                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${currentView === 'summary' ? `bg-${viewColor}-600 text-white` : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700'}`}>
+                  className={`px-3 py-1.5 text-xs font-medium transition-colors ${currentView === 'summary' ? viewActiveClass : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-700'}`}>
                   Zbiorczy
                 </button>
               </div>

--- a/apps/frontend/app/dashboard/reservations/[id]/components/ReservationHero.tsx
+++ b/apps/frontend/app/dashboard/reservations/[id]/components/ReservationHero.tsx
@@ -44,7 +44,7 @@ export function ReservationHero({
       badges={
         <>
           {isArchived && reservation.status !== 'ARCHIVED' && (
-            <Badge className="bg-neutral-200 text-neutral-800 border-neutral-300">
+            <Badge className="bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-200 border-neutral-300 dark:border-neutral-600">
               <Archive className="h-3 w-3 mr-1" />
               Zarchiwizowane
             </Badge>

--- a/apps/frontend/app/dashboard/reservations/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/[id]/page.tsx
@@ -31,6 +31,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
 import { SectionCard } from '@/components/shared/SectionCard'
 import { FilterTabs } from '@/components/shared/FilterTabs'
+import { GradientDivider } from '@/components/shared/GradientDivider'
 import { ReservationTimeline } from '@/components/reservations/ReservationTimeline'
 import { ReservationHero } from './components/ReservationHero'
 import { QuickActionsCard } from './components/QuickActionsCard'
@@ -235,6 +236,8 @@ export default function ReservationDetailsPage() {
 
         {/* Status Timeline */}
         <ReservationTimeline status={reservation.status} />
+
+        <GradientDivider />
 
         {/* US-9.8: Tab bar */}
         <FilterTabs

--- a/apps/frontend/app/dashboard/reservations/[id]/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/[id]/page.tsx
@@ -30,6 +30,7 @@ import { toast } from 'sonner'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Breadcrumb } from '@/components/shared/Breadcrumb'
 import { SectionCard } from '@/components/shared/SectionCard'
+import { FilterTabs } from '@/components/shared/FilterTabs'
 import { ReservationTimeline } from '@/components/reservations/ReservationTimeline'
 import { ReservationHero } from './components/ReservationHero'
 import { QuickActionsCard } from './components/QuickActionsCard'
@@ -236,30 +237,14 @@ export default function ReservationDetailsPage() {
         <ReservationTimeline status={reservation.status} />
 
         {/* US-9.8: Tab bar */}
-        <div className="flex gap-1 bg-muted/50 p-1 rounded-xl w-fit">
-          <button
-            onClick={() => setActiveTab('details')}
-            className={`flex items-center gap-2 px-3 sm:px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
-              activeTab === 'details'
-                ? 'bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 shadow-sm'
-                : 'text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-200'
-            }`}
-          >
-            <Calendar className="h-4 w-4" />
-            Szczegóły
-          </button>
-          <button
-            onClick={() => setActiveTab('history')}
-            className={`flex items-center gap-2 px-3 sm:px-5 py-2.5 rounded-lg text-sm font-medium transition-all ${
-              activeTab === 'history'
-                ? 'bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100 shadow-sm'
-                : 'text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-200'
-            }`}
-          >
-            <History className="h-4 w-4" />
-            Historia
-          </button>
-        </div>
+        <FilterTabs
+          tabs={[
+            { key: 'details', label: 'Szczegóły', icon: Calendar },
+            { key: 'history', label: 'Historia', icon: History },
+          ]}
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as TabType)}
+        />
 
         {/* Tab: Szczegóły */}
         {activeTab === 'details' && (

--- a/apps/frontend/app/dashboard/reservations/calendar/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/calendar/page.tsx
@@ -22,7 +22,7 @@ import {
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { PageLayout, PageHero, StatCard, ErrorState } from '@/components/shared'
+import { PageLayout, PageHero, StatCard, ErrorState, FilterTabs } from '@/components/shared'
 import { moduleAccents, statGradients, layout } from '@/lib/design-tokens'
 import { getReservations } from '@/lib/api/reservations'
 import {
@@ -274,19 +274,16 @@ export default function CalendarPage() {
       {/* Controls bar */}
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-          <div className="flex items-center gap-1 bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1">
-            <Link
-              href="/dashboard/reservations/list"
-              className="flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 rounded-md text-sm font-medium text-neutral-500 dark:text-neutral-300 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700/50 transition-colors"
-            >
-              <List className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Lista</span>
-            </Link>
-            <span className="flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 rounded-md bg-white dark:bg-neutral-700 text-sm font-medium text-neutral-900 dark:text-neutral-100 shadow-sm">
-              <CalendarDays className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Kalendarz</span>
-            </span>
-          </div>
+          <FilterTabs
+            tabs={[
+              { key: 'list', label: 'Lista', icon: List },
+              { key: 'calendar', label: 'Kalendarz', icon: CalendarDays },
+            ]}
+            activeKey="calendar"
+            onChange={(key) => {
+              if (key === 'list') router.push('/dashboard/reservations/list')
+            }}
+          />
 
           <div className="flex items-center gap-1 sm:gap-2 ml-auto sm:ml-0">
             <button onClick={goToPrevMonth} className="p-2 rounded-lg bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors shadow-sm">

--- a/apps/frontend/app/dashboard/reservations/calendar/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/calendar/page.tsx
@@ -421,7 +421,6 @@ export default function CalendarPage() {
                                 className="block p-3 rounded-xl border border-neutral-200 dark:border-neutral-700/50 bg-white dark:bg-neutral-800/80 hover:shadow-md transition-shadow"
                               >
                                 <div className="flex items-center justify-between">
-                                  <Breadcrumb />
                                   <span className="text-sm font-medium text-neutral-900 dark:text-neutral-100">
                                     <Clock className="inline h-3.5 w-3.5 mr-1 text-neutral-500" />
                                     {r.startTime} - {r.endTime}

--- a/apps/frontend/app/dashboard/reservations/list/page.tsx
+++ b/apps/frontend/app/dashboard/reservations/list/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
-import { Plus, Calendar, CheckCircle2, Clock, TrendingUp } from 'lucide-react'
+import { Plus, Calendar, CalendarDays, CheckCircle2, Clock, List, TrendingUp } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { ReservationsList } from '@/components/reservations/reservations-list'
@@ -85,8 +85,8 @@ export default function ReservationsListPage() {
       {/* View toggle */}
       <FilterTabs
         tabs={[
-          { key: 'list', label: 'Lista' },
-          { key: 'calendar', label: 'Kalendarz' },
+          { key: 'list', label: 'Lista', icon: List },
+          { key: 'calendar', label: 'Kalendarz', icon: CalendarDays },
         ]}
         activeKey="list"
         onChange={(key) => {

--- a/apps/frontend/app/globals.css
+++ b/apps/frontend/app/globals.css
@@ -239,6 +239,11 @@
   50% { opacity: 0.4; }
 }
 
+@keyframes skeleton-shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
 .animate-fade-in {
   animation: fadeIn 0.3s ease-in-out;
 }
@@ -252,7 +257,14 @@
 }
 
 .animate-skeleton {
-  animation: skeleton-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  animation: skeleton-shimmer 2s ease-in-out infinite;
+  background: linear-gradient(
+    90deg,
+    hsl(var(--muted)) 25%,
+    hsl(var(--muted-foreground) / 0.08) 50%,
+    hsl(var(--muted)) 75%
+  );
+  background-size: 200% 100%;
 }
 
 /* === Premium Glass Effect utility === */

--- a/apps/frontend/components/audit-log/EntityActivityTimeline.tsx
+++ b/apps/frontend/components/audit-log/EntityActivityTimeline.tsx
@@ -107,7 +107,7 @@ function TimelineItem({ log, index, isLast }: { log: AuditLogEntry; index: numbe
           <div className="flex items-center gap-2 flex-wrap">
             <Badge
               variant="outline"
-              className={`text-xs font-medium ${actionColors[log.action] || 'bg-neutral-100 text-neutral-700'}`}
+              className={`text-xs font-medium ${actionColors[log.action] || 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300'}`}
             >
               {actionLabels[log.action] || log.action}
             </Badge>

--- a/apps/frontend/components/audit-log/LogActionBadge.tsx
+++ b/apps/frontend/components/audit-log/LogActionBadge.tsx
@@ -9,7 +9,7 @@ export function LogActionBadge({ action, size = 'normal' }: { action: string; si
   return (
     <Badge
       variant="outline"
-      className={`${sizeClass} font-medium whitespace-nowrap ${actionColors[action] || 'bg-neutral-100 text-neutral-700 border-neutral-200'}`}
+      className={`${sizeClass} font-medium whitespace-nowrap ${actionColors[action] || 'bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 border-neutral-200 dark:border-neutral-700'}`}
     >
       {actionLabels[action] || action}
     </Badge>

--- a/apps/frontend/components/clients/contacts-manager.tsx
+++ b/apps/frontend/components/clients/contacts-manager.tsx
@@ -184,7 +184,7 @@ export function ContactsManager({ clientId, contacts, readOnly = false, onUpdate
               <h3 className="font-semibold text-amber-700 dark:text-amber-400 text-sm">
                 {editingId ? 'Edytuj osobę kontaktową' : 'Nowa osoba kontaktowa'}
               </h3>
-              <Button type="button" variant="ghost" size="sm" onClick={closeForm} className="h-7 w-7 p-0">
+              <Button type="button" variant="ghost" size="icon" onClick={closeForm}>
                 <X className="h-4 w-4" />
               </Button>
             </div>
@@ -270,7 +270,7 @@ export function ContactsManager({ clientId, contacts, readOnly = false, onUpdate
                   {!readOnly && (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-7 w-7 p-0 shrink-0 text-muted-foreground hover:text-foreground">
+                        <Button variant="ghost" size="icon" className="shrink-0 text-muted-foreground hover:text-foreground">
                           <MoreHorizontal className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>

--- a/apps/frontend/components/deposits/deposit-actions.tsx
+++ b/apps/frontend/components/deposits/deposit-actions.tsx
@@ -176,7 +176,7 @@ export function DepositActions({ deposit, onUpdate }: DepositActionsProps) {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="sm" className="h-8 w-8 p-0 hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Akcje zaliczki">
+          <Button variant="ghost" size="icon" className="hover:bg-neutral-100 dark:hover:bg-neutral-800" aria-label="Akcje zaliczki">
             <MoreHorizontal className="h-4 w-4" />
           </Button>
         </DropdownMenuTrigger>

--- a/apps/frontend/components/queue/add-to-queue-form.tsx
+++ b/apps/frontend/components/queue/add-to-queue-form.tsx
@@ -193,7 +193,7 @@ export function AddToQueueForm({ clients, onSubmit, onCancel, onClientAdded }: A
                         {filteredClients.map((client) => (
                           <div
                             key={client.id}
-                            className="px-3 py-2 cursor-pointer hover:bg-neutral-100"
+                            className="px-3 py-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700"
                             onClick={() => handleClientSelect(client)}
                           >
                             {client.firstName} {client.lastName} ({client.phone})

--- a/apps/frontend/components/service-extras/category-list/SortableCategoryRows.tsx
+++ b/apps/frontend/components/service-extras/category-list/SortableCategoryRows.tsx
@@ -126,10 +126,10 @@ export function SortableCategoryRows({
             <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => onCreateItem(category.id)}>
               <Plus className="mr-1 h-3.5 w-3.5" />Dodaj
             </Button>
-            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onEditCategory(category)} aria-label="Edytuj kategorię">
+            <Button variant="ghost" size="icon" onClick={() => onEditCategory(category)} aria-label="Edytuj kategorię">
               <Edit className="h-4 w-4" />
             </Button>
-            <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onDeleteCategory(category)} aria-label="Usuń kategorię">
+            <Button variant="ghost" size="icon" onClick={() => onDeleteCategory(category)} aria-label="Usuń kategorię">
               <Trash2 className="h-4 w-4 text-destructive" />
             </Button>
           </div>
@@ -180,10 +180,10 @@ export function SortableCategoryRows({
           </TableCell>
           <TableCell>
             <div className="flex items-center justify-end gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
-              <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => onEditItem(item)} aria-label="Edytuj pozycję">
+              <Button variant="ghost" size="icon" onClick={() => onEditItem(item)} aria-label="Edytuj pozycję">
                 <Edit className="h-3.5 w-3.5" />
               </Button>
-              <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => onDeleteItem(item)} aria-label="Usuń pozycję">
+              <Button variant="ghost" size="icon" onClick={() => onDeleteItem(item)} aria-label="Usuń pozycję">
                 <Trash2 className="h-3.5 w-3.5 text-destructive" />
               </Button>
             </div>

--- a/apps/frontend/components/shared/AnimatedCounter.tsx
+++ b/apps/frontend/components/shared/AnimatedCounter.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useInView } from 'framer-motion'
+
+interface AnimatedCounterProps {
+  /** Target value to count up to */
+  value: number
+  /** Duration of the animation in ms */
+  duration?: number
+  /** Format function for the displayed value */
+  formatFn?: (n: number) => string
+  className?: string
+}
+
+/**
+ * AnimatedCounter — Smooth count-up animation for numeric values.
+ * Triggers when the element enters the viewport.
+ */
+export function AnimatedCounter({
+  value,
+  duration = 800,
+  formatFn,
+  className,
+}: AnimatedCounterProps) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const isInView = useInView(ref, { once: true, margin: '-40px' })
+  const [displayValue, setDisplayValue] = useState(0)
+
+  useEffect(() => {
+    if (!isInView) return
+
+    const startTime = performance.now()
+    const startValue = 0
+
+    const animate = (currentTime: number) => {
+      const elapsed = currentTime - startTime
+      const progress = Math.min(elapsed / duration, 1)
+      // Ease-out cubic
+      const eased = 1 - Math.pow(1 - progress, 3)
+      const current = Math.round(startValue + (value - startValue) * eased)
+
+      setDisplayValue(current)
+
+      if (progress < 1) {
+        requestAnimationFrame(animate)
+      }
+    }
+
+    requestAnimationFrame(animate)
+  }, [isInView, value, duration])
+
+  const formatted = formatFn ? formatFn(displayValue) : String(displayValue)
+
+  return (
+    <span ref={ref} className={className}>
+      {formatted}
+    </span>
+  )
+}

--- a/apps/frontend/components/shared/DetailHero.tsx
+++ b/apps/frontend/components/shared/DetailHero.tsx
@@ -72,6 +72,8 @@ export function DetailHero({
       className
     )}>
       <div className="absolute inset-0 bg-grid-white/10 [mask-image:radial-gradient(white,transparent_85%)]" />
+      {/* Noise texture overlay for premium depth */}
+      <div className="absolute inset-0 opacity-[0.03] mix-blend-overlay" style={{ backgroundImage: "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")" }} />
 
       <div className="relative z-10 space-y-4 sm:space-y-6">
         <div className="flex items-center justify-between">

--- a/apps/frontend/components/shared/FilterTabs.tsx
+++ b/apps/frontend/components/shared/FilterTabs.tsx
@@ -34,7 +34,7 @@ export function FilterTabs({ tabs, activeKey, onChange, className, width = 'auto
   return (
     <div className={cn(
       'inline-flex items-center gap-1 bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1',
-      width === 'full' && 'w-full sm:w-auto',
+      width === 'full' && 'w-full sm:w-fit',
       className
     )}>
       {tabs.map((tab) => {

--- a/apps/frontend/components/shared/FilterTabs.tsx
+++ b/apps/frontend/components/shared/FilterTabs.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { cn } from '@/lib/utils'
+import type { LucideIcon } from 'lucide-react'
 
 export interface FilterTab {
   key: string
   label: string
   count?: number
+  icon?: LucideIcon
 }
 
 export interface FilterTabsProps {
@@ -13,36 +15,44 @@ export interface FilterTabsProps {
   activeKey: string
   onChange: (key: string) => void
   className?: string
+  /** Responsive width — 'auto' (default) = fits content, 'full' = full width on mobile */
+  width?: 'auto' | 'full'
 }
 
 /**
- * FilterTabs — Unified pill-style tab filter used across all modules.
+ * FilterTabs — Unified pill-style tab navigation used across all modules.
  *
  * Provides:
  * - Pill tabs inside a container background
  * - Active state with white bg + shadow
  * - Optional badge count per tab
+ * - Optional Lucide icon per tab
+ * - Responsive width mode (auto / full on mobile)
  * - Full dark mode support
  */
-export function FilterTabs({ tabs, activeKey, onChange, className }: FilterTabsProps) {
+export function FilterTabs({ tabs, activeKey, onChange, className, width = 'auto' }: FilterTabsProps) {
   return (
     <div className={cn(
       'inline-flex items-center gap-1 bg-neutral-100 dark:bg-neutral-800 rounded-lg p-1',
+      width === 'full' && 'w-full sm:w-auto',
       className
     )}>
       {tabs.map((tab) => {
         const isActive = tab.key === activeKey
+        const Icon = tab.icon
         return (
           <button
             key={tab.key}
             onClick={() => onChange(tab.key)}
             className={cn(
               'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200',
+              width === 'full' && 'flex-1 justify-center',
               isActive
                 ? 'bg-white dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100 shadow-sm'
                 : 'text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-neutral-200 hover:bg-neutral-50 dark:hover:bg-neutral-700/50'
             )}
           >
+            {Icon && <Icon className="h-4 w-4 flex-shrink-0" />}
             {tab.label}
             {tab.count !== undefined && tab.count > 0 && (
               <span className={cn(

--- a/apps/frontend/components/shared/GradientDivider.tsx
+++ b/apps/frontend/components/shared/GradientDivider.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { cn } from '@/lib/utils'
+
+interface GradientDividerProps {
+  className?: string
+  /** Accent color for the center of the gradient, defaults to border color */
+  accent?: 'primary' | 'border' | 'muted'
+}
+
+/**
+ * GradientDivider — Premium section separator with gradient fade.
+ * Transparent at both ends, colored in the middle.
+ */
+export function GradientDivider({ className, accent = 'border' }: GradientDividerProps) {
+  return (
+    <div
+      className={cn(
+        'h-px w-full',
+        accent === 'border' && 'bg-gradient-to-r from-transparent via-border to-transparent',
+        accent === 'primary' && 'bg-gradient-to-r from-transparent via-primary/20 to-transparent',
+        accent === 'muted' && 'bg-gradient-to-r from-transparent via-muted-foreground/15 to-transparent',
+        className
+      )}
+      role="separator"
+    />
+  )
+}

--- a/apps/frontend/components/shared/StatCard.tsx
+++ b/apps/frontend/components/shared/StatCard.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { motionTokens } from '@/lib/design-tokens'
 import { type LucideIcon, TrendingUp, TrendingDown, Minus } from 'lucide-react'
+import { AnimatedCounter } from './AnimatedCounter'
 
 interface StatCardProps {
   /** Card title / label */
@@ -122,9 +123,13 @@ export function StatCard({
           </div>
         </div>
 
-        {/* Row 2: Value */}
+        {/* Row 2: Value — animated count-up for pure numbers */}
         <p className="text-2xl sm:text-3xl font-bold text-neutral-900 dark:text-neutral-100 tabular-nums">
-          {value}
+          {typeof value === 'number' ? (
+            <AnimatedCounter value={value} duration={800} />
+          ) : (
+            value
+          )}
         </p>
 
         {/* Row 3: Change indicator */}

--- a/apps/frontend/components/shared/StatusBadge.tsx
+++ b/apps/frontend/components/shared/StatusBadge.tsx
@@ -1,6 +1,11 @@
 import { cn } from '@/lib/utils'
 import { getStatusConfig, type StatusType } from '@/lib/status-colors'
 
+/** Statuses that represent "in progress" — get a ping animation on the dot */
+const ACTIVE_STATUSES = new Set([
+  'PENDING', 'CONFIRMED', 'IN_PREPARATION', 'WAITING', 'DRAFT', 'INQUIRY', 'QUOTED',
+])
+
 interface StatusBadgeProps {
   /** Entity type — selects the correct color map */
   type: StatusType
@@ -12,6 +17,8 @@ interface StatusBadgeProps {
   showIcon?: boolean
   /** Show text label (default: true) */
   showLabel?: boolean
+  /** Show ping animation on dot for active statuses (default: true) */
+  ping?: boolean
   className?: string
 }
 
@@ -25,11 +32,13 @@ export function StatusBadge({
   variant = 'default',
   showIcon,
   showLabel = true,
+  ping = true,
   className,
 }: StatusBadgeProps) {
   const config = getStatusConfig(type, status)
   const Icon = config.icon
   const shouldShowIcon = showIcon ?? (variant !== 'dot')
+  const showPing = ping && ACTIVE_STATUSES.has(status)
 
   if (variant === 'solid') {
     return (
@@ -51,7 +60,15 @@ export function StatusBadge({
         config.text,
         className,
       )}>
-        <span className={cn('h-2 w-2 rounded-full', config.dot)} />
+        <span className="relative flex h-2 w-2">
+          {showPing && (
+            <span className={cn(
+              'absolute inline-flex h-full w-full rounded-full opacity-75 animate-ping',
+              config.dot,
+            )} />
+          )}
+          <span className={cn('relative inline-flex h-2 w-2 rounded-full', config.dot)} />
+        </span>
         {showLabel && config.label}
       </span>
     )

--- a/apps/frontend/components/shared/index.ts
+++ b/apps/frontend/components/shared/index.ts
@@ -1,4 +1,6 @@
+export { AnimatedCounter } from './AnimatedCounter'
 export { AnimatedSection } from './AnimatedSection'
+export { GradientDivider } from './GradientDivider'
 export { PageLayout } from './PageLayout'
 export { PageHero } from './PageHero'
 export { StatCard } from './StatCard'

--- a/apps/frontend/components/ui/dropdown-menu.tsx
+++ b/apps/frontend/components/ui/dropdown-menu.tsx
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover p-1 text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover/95 backdrop-blur-lg p-1 text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover p-1 text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover/95 backdrop-blur-lg p-1 text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/frontend/components/ui/popover.tsx
+++ b/apps/frontend/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 w-72 rounded-xl border border-neutral-100 dark:border-neutral-700/50 bg-popover/95 backdrop-blur-lg text-popover-foreground shadow-lg dark:shadow-2xl dark:shadow-black/30 outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/apps/frontend/components/ui/select.tsx
+++ b/apps/frontend/components/ui/select.tsx
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-lg border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-lg border bg-popover/95 backdrop-blur-lg text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/apps/frontend/components/ui/stepper.tsx
+++ b/apps/frontend/components/ui/stepper.tsx
@@ -243,7 +243,7 @@ export function StepNavigation({
   const isFirstStep = currentStep === 0
 
   return (
-    <div className={cn('flex items-center justify-between pt-6 border-t border-secondary-200', className)}>
+    <div className={cn('flex items-center justify-between pt-6 border-t border-secondary-200 dark:border-neutral-700', className)}>
       <button
         type="button"
         onClick={onPrev}
@@ -251,8 +251,8 @@ export function StepNavigation({
         className={cn(
           'flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-colors',
           isFirstStep
-            ? 'text-neutral-300 cursor-not-allowed'
-            : 'text-neutral-700 hover:bg-secondary-100'
+            ? 'text-neutral-300 dark:text-neutral-600 cursor-not-allowed'
+            : 'text-neutral-700 dark:text-neutral-300 hover:bg-secondary-100 dark:hover:bg-neutral-800'
         )}
       >
         <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">


### PR DESCRIPTION
## Summary
Realizacja etapów 7-10 z planu Premium UI Overhaul (EPIC #519):

- **#541 UnifiedTabNav** — rozszerzenie FilterTabs o ikony + migracja tabów na detail pages i calendar
- **#542 Premium Polish** — AnimatedCounter, GradientDivider, StatusDot ping, glass effects, skeleton shimmer
- **#543 Responsive Excellence** — audyt mobile, fix touch targets 44px, usunięcie stray Breadcrumb
- **#544 Dark Mode Perfection** — audyt dark mode, fix contrast badges, fallback colors, dynamic classes

### Zmiany w szczegółach

**TabNav (#541)**
- FilterTabs rozszerzony o opcjonalny `icon` prop i tryb `width='full'`
- Reservation detail: custom buttons → FilterTabs z ikonami
- Client detail: custom buttons → FilterTabs z ikonami
- Calendar page: hardcoded Link/span → FilterTabs z ikonami
- List page: dodane ikony List/CalendarDays do view toggle

**Premium Polish (#542)**
- Nowy komponent `AnimatedCounter` — count-up na viewport entry (ease-out cubic)
- Integracja AnimatedCounter w StatCard dla wartości numerycznych
- Nowy komponent `GradientDivider` — separator sekcji z gradient fade
- StatusBadge dot variant: ping animation na aktywnych statusach (PENDING, CONFIRMED, etc.)
- Glass effect (backdrop-blur-lg) na SelectContent, PopoverContent, DropdownMenuContent
- Noise texture overlay na DetailHero (jak PageHero)
- Skeleton shimmer: gradient sweep zamiast pulse

**Responsive (#543)**
- Icon buttons → size="icon" (44x44px) w contacts-manager, deposit-actions, SortableCategoryRows
- Usunięcie stray `<Breadcrumb />` renderowanego w pętli mobile agenda na calendar page

**Dark Mode (#544)**
- ReservationHero archived badge: dark variants
- LogActionBadge/EntityActivityTimeline: fallback colors z dark variants
- add-to-queue-form dropdown: dark hover state
- ReportFilters: focus border dark, fix dynamic Tailwind classes
- Stepper: Previous button dark text + hover + border

## Test plan
- [ ] `make dev-build` na VPS
- [ ] Weryfikacja FilterTabs z ikonami na: reservation detail, client detail, calendar, list
- [ ] Weryfikacja AnimatedCounter na StatCards (dashboard, list pages)
- [ ] Weryfikacja GradientDivider na reservation i client detail
- [ ] Weryfikacja StatusBadge ping na aktywnych statusach
- [ ] Weryfikacja glass effect na dropdown/select/popover
- [ ] Weryfikacja skeleton shimmer gradient
- [ ] Touch targets: contacts-manager, deposit-actions, SortableCategoryRows
- [ ] Dark mode: badges, ReportFilters, stepper, queue form
- [ ] `make test-frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)